### PR TITLE
Feat : cached_movie_table 컬럼 추가

### DIFF
--- a/application/src/main/java/core/application/movies/models/entities/CachedMovieEntity.java
+++ b/application/src/main/java/core/application/movies/models/entities/CachedMovieEntity.java
@@ -1,5 +1,8 @@
 package core.application.movies.models.entities;
 
+import java.util.List;
+
+import core.application.movies.constant.Genre;
 import lombok.*;
 
 @Getter
@@ -14,6 +17,12 @@ public class CachedMovieEntity {
     private String movieId;
     private String title;
     private String posterUrl;
+    private Genre genre;
+    private String releaseDate;
+    private String plot;
+    private String runningTime;
+    private String actors;
+    private String director;
     private Long   dibCount;
     private Long   reviewCount;
     private Long   commentCount;


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
cached_movie_table에 컬럼 추가가 필요할 것 같아 추가한 내용입니다.

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
기존 cached_movie_table에서 컬럼을 추가하였습니다.
추가된 컬럼은 다음과 같습니다.

```sql
    genre         varchar(50)      not null comment '영화 장르',
    release_date  varchar(30)      not null comment '영화 개봉일',
    plot          text             not null comment '영화 줄거리',
    running_time  varchar(10)      not null comment '영화 상영시간',
    actors        varchar(180)     not null comment '출연 배우 5명',
    director      varchar(30)      not null comment '감독',
```

- 위 테이블 구조로 수정 시, 메인 페이지 영화 목록의 경우 `cached_movie_table` 조회 후 `KMDB API`를 통해 개봉일을 불러와야 합니다. 하지만 수정 시, `cached_movie_table` 조회 만으로 해결 가능하게 됩니다.

- 영화 상세페이지의 경우 기존에는 `KMDB API` 사용 후 `cached_movie_table`을 조회해야 합니다. 하지만 수정 시, **`cached_movie_table` 조회한 후 없을 시 에만** `KMDB API`를 사용하면 됩니다.

## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
