### PR TITLE
Feat : 한줄평 검색, 좋아요 및 싫어요 기능 구현

### DIFF
--- a/application/src/main/java/core/application/movies/constant/CommentSort.java
+++ b/application/src/main/java/core/application/movies/constant/CommentSort.java
@@ -1,0 +1,16 @@
+package core.application.movies.constant;
+
+public enum CommentSort {
+	LATEST,
+	LIKE,
+	DISLIKE;
+
+	public static Boolean isValid(String value) {
+		for (CommentSort sort : CommentSort.values()) {
+			if (sort.name().equals(value)) {
+				return true;
+			}
+		}
+		return false;
+	}
+}

--- a/application/src/main/java/core/application/movies/controller/CommentController.java
+++ b/application/src/main/java/core/application/movies/controller/CommentController.java
@@ -1,0 +1,85 @@
+package core.application.movies.controller;
+
+import java.util.List;
+
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import core.application.movies.constant.CommentSort;
+import core.application.movies.exception.WrongWriteCommentException;
+import core.application.movies.models.dto.CommentReactionDTO;
+import core.application.movies.models.dto.CommentRespDTO;
+import core.application.movies.models.dto.CommentWriteReqDTO;
+import core.application.movies.service.CommentService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/movies")
+public class CommentController {
+	private final CommentService commentService;
+
+	@GetMapping("/{movieId}/comments")
+	public List<CommentRespDTO> getComments(@PathVariable String movieId, @RequestParam int page, @RequestParam
+	String sortType) {
+		/**
+		 * 추후 JWT를 통해 userId 주입
+		 * 잘못된 정렬 타입은 좋아요 순으로 제공한다.
+		 */
+		if (!CommentSort.isValid(sortType)) {
+			return commentService.getComments(movieId, page, CommentSort.LIKE, null);
+		}
+		CommentSort sort = CommentSort.valueOf(sortType);
+		return commentService.getComments(movieId, page, sort, null);
+	}
+
+	@PostMapping("/{movieId}/comments")
+	public CommentRespDTO writeComment(@PathVariable String movieId,
+		@RequestBody @Validated CommentWriteReqDTO writeReqDTO, BindingResult bindingResult) {
+		if (bindingResult.hasErrors()) {
+			log.info("검증 오류 발생 : {}", bindingResult);
+			throw new WrongWriteCommentException(bindingResult.getAllErrors().get(0).getDefaultMessage());
+		}
+
+		// TODO JWT 토큰 구현 시, 유저 정보 추출 로직 필요
+		return commentService.writeCommentOnMovie(writeReqDTO, null, movieId);
+	}
+
+	@PostMapping("/{movieId}/comments/{commentId}/like")
+	public CommentReactionDTO incrementCommentLike(@PathVariable Long commentId) {
+		// 추후 JWT 구현 시 userId 삽입
+		commentService.incrementCommentLike(commentId, null);
+		return new CommentReactionDTO("한줄평 좋아요 완료");
+	}
+
+	@DeleteMapping("/{movieId}/comments/{commentId}/like")
+	public CommentReactionDTO decrementCommentLike(@PathVariable Long commentId) {
+		// 추후 JWT 구현 시 userId 삽입
+		commentService.decrementCommentLike(commentId, null);
+		return new CommentReactionDTO("한줄평 좋아요 취소 완료");
+	}
+
+	@PostMapping("/{movieId}/comments/{commentId}/dislike")
+	public CommentReactionDTO incrementCommentDislike(@PathVariable Long commentId) {
+		// 추후 JWT 구현 시 userId 삽입
+		commentService.incrementCommentDislike(commentId, null);
+		return new CommentReactionDTO("한줄평 싫어요 취소 완료");
+	}
+
+	@DeleteMapping("/{movieId}/comments/{commentId}/dislike")
+	public CommentReactionDTO decrementCommentDislike(@PathVariable Long commentId) {
+		// 추후 JWT 구현 시 userId 삽입
+		commentService.decrementCommentDislike(commentId, null);
+		return new CommentReactionDTO("한줄평 좋아요 완료");
+	}
+}

--- a/application/src/main/java/core/application/movies/controller/MovieExceptionAdvice.java
+++ b/application/src/main/java/core/application/movies/controller/MovieExceptionAdvice.java
@@ -1,0 +1,25 @@
+package core.application.movies.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import core.application.movies.exception.ExceptionResult;
+import core.application.movies.exception.InvalidReactionException;
+import core.application.movies.exception.NotFoundCommentException;
+import core.application.movies.exception.WrongWriteCommentException;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestControllerAdvice
+public class MovieExceptionAdvice {
+
+	@ResponseStatus(HttpStatus.BAD_REQUEST)
+	@ExceptionHandler({NotFoundCommentException.class, InvalidReactionException.class,
+		WrongWriteCommentException.class})
+	public ExceptionResult handleNotFoundCommentException(NotFoundCommentException e) {
+		log.error(e.getMessage());
+		return new ExceptionResult(e.getMessage());
+	}
+}

--- a/application/src/main/java/core/application/movies/exception/ExceptionResult.java
+++ b/application/src/main/java/core/application/movies/exception/ExceptionResult.java
@@ -1,0 +1,10 @@
+package core.application.movies.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class ExceptionResult {
+	private String message;
+}

--- a/application/src/main/java/core/application/movies/exception/InvalidReactionException.java
+++ b/application/src/main/java/core/application/movies/exception/InvalidReactionException.java
@@ -1,0 +1,19 @@
+package core.application.movies.exception;
+
+public class InvalidReactionException extends RuntimeException {
+	public InvalidReactionException(String message) {
+		super(message);
+	}
+
+	public InvalidReactionException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public InvalidReactionException(Throwable cause) {
+		super(cause);
+	}
+
+	public InvalidReactionException() {
+		super();
+	}
+}

--- a/application/src/main/java/core/application/movies/exception/NotFoundCommentException.java
+++ b/application/src/main/java/core/application/movies/exception/NotFoundCommentException.java
@@ -1,0 +1,19 @@
+package core.application.movies.exception;
+
+public class NotFoundCommentException extends RuntimeException {
+	public NotFoundCommentException() {
+		super();
+	}
+
+	public NotFoundCommentException(String message) {
+		super(message);
+	}
+
+	public NotFoundCommentException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public NotFoundCommentException(Throwable cause) {
+		super(cause);
+	}
+}

--- a/application/src/main/java/core/application/movies/exception/WrongWriteCommentException.java
+++ b/application/src/main/java/core/application/movies/exception/WrongWriteCommentException.java
@@ -1,0 +1,19 @@
+package core.application.movies.exception;
+
+public class WrongWriteCommentException extends RuntimeException {
+	public WrongWriteCommentException(String message) {
+		super(message);
+	}
+
+	public WrongWriteCommentException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public WrongWriteCommentException(Throwable cause) {
+		super(cause);
+	}
+
+	public WrongWriteCommentException() {
+		super();
+	}
+}

--- a/application/src/main/java/core/application/movies/models/dto/CommentReactionRespDTO.java
+++ b/application/src/main/java/core/application/movies/models/dto/CommentReactionRespDTO.java
@@ -1,0 +1,10 @@
+package core.application.movies.models.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class CommentReactionRespDTO {
+	private String message;
+}

--- a/application/src/main/java/core/application/movies/models/dto/CommentRespDTO.java
+++ b/application/src/main/java/core/application/movies/models/dto/CommentRespDTO.java
@@ -1,0 +1,36 @@
+package core.application.movies.models.dto;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import core.application.movies.models.entities.CommentEntity;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class CommentRespDTO {
+	private Long commentId;
+	private String content;
+	private int like;
+	private int dislike;
+	private int rating;
+	private String movieId;
+	private UUID userId;
+	private Instant createdAt;
+	private Boolean isLiked;
+	private Boolean isDisliked;
+
+	public static CommentRespDTO from(CommentEntity comment) {
+		return CommentRespDTO.builder()
+			.commentId(comment.getCommentId())
+			.movieId(comment.getMovieId())
+			.content(comment.getContent())
+			.userId(comment.getUserId())
+			.like(comment.getLike())
+			.dislike(comment.getDislike())
+			.rating(comment.getDislike())
+			.createdAt(comment.getCreatedAt())
+			.build();
+	}
+}

--- a/application/src/main/java/core/application/movies/models/dto/CommentWriteReqDTO.java
+++ b/application/src/main/java/core/application/movies/models/dto/CommentWriteReqDTO.java
@@ -1,0 +1,17 @@
+package core.application.movies.models.dto;
+
+import org.hibernate.validator.constraints.Range;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class CommentWriteReqDTO {
+	@NotBlank(message = "공백은 입력할 수 없습니다.")
+	private String content;
+
+	@Range(min = 1, max = 10, message = "1점에서 10점 이내로 평점을 입력해주세요.")
+	private int rating;
+}

--- a/application/src/main/java/core/application/movies/models/entities/CommentEntity.java
+++ b/application/src/main/java/core/application/movies/models/entities/CommentEntity.java
@@ -1,9 +1,15 @@
 package core.application.movies.models.entities;
 
-import lombok.*;
-
 import java.time.Instant;
 import java.util.UUID;
+
+import core.application.movies.models.dto.CommentWriteReqDTO;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 @Getter
 @Builder
@@ -11,12 +17,39 @@ import java.util.UUID;
 @AllArgsConstructor
 @ToString
 public class CommentEntity {
-    private Long    commentId;
-    private String  content;
-    private int     like;
-    private int     dislike;
-    private int     rating;
-    private String  movieId;     // 영화 API 에 따라 달라질 수 있음.
-    private UUID    userId;
-    private Instant createdAt;
+	private Long commentId;
+	private String content;
+	private int like;
+	private int dislike;
+	private int rating;
+	private String movieId;     // 영화 API 에 따라 달라질 수 있음.
+	private UUID userId;
+	private Instant createdAt;
+
+	public static CommentEntity of(CommentWriteReqDTO comment, String movieId, UUID userId) {
+		return CommentEntity.builder()
+			.content(comment.getContent())
+			.like(0)
+			.dislike(0)
+			.rating(comment.getRating())
+			.movieId(movieId)
+			.userId(userId)
+			.build();
+	}
+
+	public void isLiked() {
+		this.like++;
+	}
+
+	public void cancelLike() {
+		this.like--;
+	}
+
+	public void isDisliked() {
+		this.dislike++;
+	}
+
+	public void cancelDislike() {
+		this.dislike--;
+	}
 }

--- a/application/src/main/java/core/application/movies/repositories/CommentDislikeRepository.java
+++ b/application/src/main/java/core/application/movies/repositories/CommentDislikeRepository.java
@@ -1,0 +1,27 @@
+package core.application.movies.repositories;
+
+import java.util.UUID;
+
+import org.springframework.stereotype.Repository;
+
+import core.application.movies.repositories.mapper.CommentDislikeMapper;
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class CommentDislikeRepository {
+	private final CommentDislikeMapper commentDislikeMapper;
+
+	public void saveCommentDislike(Long commentId, UUID userId) {
+		commentDislikeMapper.save(commentId, userId);
+	}
+
+	public boolean isExistDislike(Long commentId, UUID userId) {
+		int count = commentDislikeMapper.countLikeByUser(commentId, userId);
+		return count != 0;
+	}
+
+	public void deleteCommentDislike(Long commentId, UUID userId) {
+		commentDislikeMapper.delete(commentId, userId);
+	}
+}

--- a/application/src/main/java/core/application/movies/repositories/CommentLikeRepository.java
+++ b/application/src/main/java/core/application/movies/repositories/CommentLikeRepository.java
@@ -1,0 +1,27 @@
+package core.application.movies.repositories;
+
+import java.util.UUID;
+
+import org.springframework.stereotype.Repository;
+
+import core.application.movies.repositories.mapper.CommentLikeMapper;
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class CommentLikeRepository {
+	private final CommentLikeMapper commentLikeMapper;
+
+	public void saveCommentLike(Long commentId, UUID userId) {
+		commentLikeMapper.save(commentId, userId);
+	}
+
+	public boolean isExistLike(Long commentId, UUID userId) {
+		int count = commentLikeMapper.countLikeByUser(commentId, userId);
+		return count != 0;
+	}
+
+	public void deleteCommentLike(Long commentId, UUID userId) {
+		commentLikeMapper.delete(commentId, userId);
+	}
+}

--- a/application/src/main/java/core/application/movies/repositories/CommentRepository.java
+++ b/application/src/main/java/core/application/movies/repositories/CommentRepository.java
@@ -1,90 +1,98 @@
 package core.application.movies.repositories;
 
-
-import core.application.movies.models.entities.CommentEntity;
-
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+
+import core.application.movies.models.dto.CommentRespDTO;
+import core.application.movies.models.entities.CommentEntity;
 
 /**
  * {@code COMMENT_TABLE} 과 관련된 {@code Repository}
  */
 public interface CommentRepository {
 
-    // CREATE
+	// CREATE
 
-    /**
-     * 특정 영화에 주어진 유저 ID 로 새로운 한줄평 댓글을 DB 에 등록
-     *
-     * @param movieId 한줄평 댓글을 등록할 영화 ID
-     * @param userId  댓글을 등록하는 유저 ID
-     * @param comment 새로운 한줄평 댓글
-     * @return {@link CommentEntity} 등록된 정보
-     */
-    CommentEntity saveNewComment(String movieId, UUID userId, CommentEntity comment);
+	/**
+	 * 특정 영화에 주어진 유저 ID 로 새로운 한줄평 댓글을 DB 에 등록
+	 *
+	 * @param movieId 한줄평 댓글을 등록할 영화 ID
+	 * @param userId  댓글을 등록하는 유저 ID
+	 * @param comment 새로운 한줄평 댓글
+	 * @return {@link CommentEntity} 등록된 정보
+	 */
+	CommentEntity saveNewComment(String movieId, UUID userId, CommentEntity comment);
 
+	//<editor-fold desc="READ">
 
-    //<editor-fold desc="READ">
+	/**
+	 * 한줄평 댓글 ID 로 검색
+	 *
+	 * @param commentId 댓글 ID
+	 * @return {@link Optional}{@code <}{@link CommentEntity}{@code >}
+	 */
+	Optional<CommentEntity> findByCommentId(Long commentId);
 
-    /**
-     * 한줄평 댓글 ID 로 검색
-     *
-     * @param commentId 댓글 ID
-     * @return {@link Optional}{@code <}{@link CommentEntity}{@code >}
-     */
-    Optional<CommentEntity> findByCommentId(Long commentId);
+	Boolean existsByMovieIdAndUserId(String movieId, UUID userId);
 
-    /**
-     * 특정 영화에 달린 한줄평 댓글들을 검색
-     *
-     * @param movieId 검색할 영화 ID
-     * @return {@link List}{@code <}{@link CommentEntity}{@code >}
-     * @see #findByMovieIdOnDateDescend(String)
-     * @see #findByMovieIdOnLikeDescend(String)
-     * @see #findByMovieIdOnDislikeDescend(String)
-     */
-    List<CommentEntity> findByMovieId(String movieId);
+	/**
+	 * 특정 영화에 달린 한줄평 댓글들을 검색
+	 *
+	 * @param movieId 검색할 영화 ID
+	 * @return {@link List}{@code <}{@link CommentEntity}{@code >}
+	 * @see #findByMovieIdOnDateDescend(String, UUID, int)
+	 * @see #findByMovieIdOnLikeDescend(String, UUID, int)
+	 * @see #findByMovieIdOnDislikeDescend(String, UUID, int)
+	 */
+	List<CommentRespDTO> findByMovieId(String movieId, UUID userId, int offset);
 
-    /**
-     * 특정 영화에 달린 한줄평 댓글을 최신순으로 검색
-     *
-     * @param movieId 검색할 영화 ID
-     * @return {@link List}{@code <}{@link CommentEntity}{@code >}
-     */
-    List<CommentEntity> findByMovieIdOnDateDescend(String movieId);
+	/**
+	 * 특정 영화에 달린 한줄평 댓글을 최신순으로 검색
+	 *
+	 * @param movieId 검색할 영화 ID
+	 * @return {@link List}{@code <}{@link CommentEntity}{@code >}
+	 */
+	List<CommentRespDTO> findByMovieIdOnDateDescend(String movieId, UUID userId, int offset);
 
-    /**
-     * 특정 영화에 달린 한줄평 댓글을 좋아요 순으로 검색
-     *
-     * @param movieId 검색할 영화 ID
-     * @return {@link List}{@code <}{@link CommentEntity}{@code >}
-     */
-    List<CommentEntity> findByMovieIdOnLikeDescend(String movieId);
+	/**
+	 * 특정 영화에 달린 한줄평 댓글을 좋아요 순으로 검색
+	 *
+	 * @param movieId 검색할 영화 ID
+	 * @return {@link List}{@code <}{@link CommentEntity}{@code >}
+	 */
+	List<CommentRespDTO> findByMovieIdOnLikeDescend(String movieId, UUID userId, int offset);
 
-    /**
-     * 특정 영화에 달린 한줄평 댓글을 싫어요 순으로 검색
-     *
-     * @param movieId 검색할 영화 ID
-     * @return {@link List}{@code <}{@link CommentEntity}{@code >}
-     */
-    List<CommentEntity> findByMovieIdOnDislikeDescend(String movieId);
+	/**
+	 * 특정 영화에 달린 한줄평 댓글을 싫어요 순으로 검색
+	 *
+	 * @param movieId 검색할 영화 ID
+	 * @return {@link List}{@code <}{@link CommentEntity}{@code >}
+	 */
+	List<CommentRespDTO> findByMovieIdOnDislikeDescend(String movieId, UUID userId, int offset);
 
-    /**
-     * DB 의 모든 한줄평 댓글을 검색
-     *
-     * @return {@link List}{@code <}{@link CommentEntity}{@code >}
-     */
-    List<CommentEntity> selectAll();
-    //</editor-fold>
+	/**
+	 * DB 의 모든 한줄평 댓글을 검색
+	 *
+	 * @return {@link List}{@code <}{@link CommentEntity}{@code >}
+	 */
+	List<CommentEntity> selectAll();
+	//</editor-fold>
 
+	// UPDATE
 
-    // DELETE
+	/**
+	 * 한줄평 내용 수정
+	 * @param comment 수정할 한줄평
+	 */
+	public void update(CommentEntity comment);
 
-    /**
-     * 특정 한줄평 댓글을 삭제
-     *
-     * @param commentId 삭제할 한줄평 댓글의 ID
-     */
-    void deleteComment(Long commentId);
+	// DELETE
+
+	/**
+	 * 특정 한줄평 댓글을 삭제
+	 *
+	 * @param commentId 삭제할 한줄평 댓글의 ID
+	 */
+	void deleteComment(Long commentId);
 }

--- a/application/src/main/java/core/application/movies/repositories/CommentRepositoryImpl.java
+++ b/application/src/main/java/core/application/movies/repositories/CommentRepositoryImpl.java
@@ -1,0 +1,59 @@
+package core.application.movies.repositories;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.stereotype.Repository;
+
+import core.application.movies.models.entities.CommentEntity;
+import core.application.movies.repositories.mapper.CommentMapper;
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class CommentRepositoryImpl implements CommentRepository {
+
+	private final CommentMapper commentMapper;
+
+	@Override
+	public CommentEntity saveNewComment(String movieId, UUID userId, CommentEntity comment) {
+		commentMapper.save(movieId, userId, comment);
+		return findByCommentId(comment.getCommentId()).orElse(null);
+	}
+
+	@Override
+	public Optional<CommentEntity> findByCommentId(Long commentId) {
+		return commentMapper.findByCommentId(commentId);
+	}
+
+	@Override
+	public List<CommentEntity> findByMovieId(String movieId) {
+		return commentMapper.findByMovieId(movieId);
+	}
+
+	@Override
+	public List<CommentEntity> findByMovieIdOnDateDescend(String movieId) {
+		return commentMapper.findByMovieIdOnDateDescend(movieId);
+	}
+
+	@Override
+	public List<CommentEntity> findByMovieIdOnLikeDescend(String movieId) {
+		return commentMapper.findByMovieIdOnLikeDescend(movieId);
+	}
+
+	@Override
+	public List<CommentEntity> findByMovieIdOnDislikeDescend(String movieId) {
+		return commentMapper.findByMovieIdOnDislikeDescend(movieId);
+	}
+
+	@Override
+	public List<CommentEntity> selectAll() {
+		return commentMapper.selectAll();
+	}
+
+	@Override
+	public void deleteComment(Long commentId) {
+		commentMapper.delete(commentId);
+	}
+}

--- a/application/src/main/java/core/application/movies/repositories/CommentRepositoryImpl.java
+++ b/application/src/main/java/core/application/movies/repositories/CommentRepositoryImpl.java
@@ -6,6 +6,7 @@ import java.util.UUID;
 
 import org.springframework.stereotype.Repository;
 
+import core.application.movies.models.dto.CommentRespDTO;
 import core.application.movies.models.entities.CommentEntity;
 import core.application.movies.repositories.mapper.CommentMapper;
 import lombok.RequiredArgsConstructor;
@@ -28,28 +29,38 @@ public class CommentRepositoryImpl implements CommentRepository {
 	}
 
 	@Override
-	public List<CommentEntity> findByMovieId(String movieId) {
-		return commentMapper.findByMovieId(movieId);
+	public Boolean existsByMovieIdAndUserId(String movieId, UUID userId) {
+		return commentMapper.findByMovieIdAndUserId(movieId, userId).isPresent();
 	}
 
 	@Override
-	public List<CommentEntity> findByMovieIdOnDateDescend(String movieId) {
-		return commentMapper.findByMovieIdOnDateDescend(movieId);
+	public List<CommentRespDTO> findByMovieId(String movieId, UUID userId, int offset) {
+		return commentMapper.findByMovieId(movieId, userId, offset);
 	}
 
 	@Override
-	public List<CommentEntity> findByMovieIdOnLikeDescend(String movieId) {
-		return commentMapper.findByMovieIdOnLikeDescend(movieId);
+	public List<CommentRespDTO> findByMovieIdOnDateDescend(String movieId, UUID userId, int offset) {
+		return commentMapper.findByMovieIdOnDateDescend(movieId, userId, offset);
 	}
 
 	@Override
-	public List<CommentEntity> findByMovieIdOnDislikeDescend(String movieId) {
-		return commentMapper.findByMovieIdOnDislikeDescend(movieId);
+	public List<CommentRespDTO> findByMovieIdOnLikeDescend(String movieId, UUID userId, int offset) {
+		return commentMapper.findByMovieIdOnLikeDescend(movieId, userId, offset);
+	}
+
+	@Override
+	public List<CommentRespDTO> findByMovieIdOnDislikeDescend(String movieId, UUID userId, int offset) {
+		return commentMapper.findByMovieIdOnDislikeDescend(movieId, userId, offset);
 	}
 
 	@Override
 	public List<CommentEntity> selectAll() {
 		return commentMapper.selectAll();
+	}
+
+	@Override
+	public void update(CommentEntity comment) {
+		commentMapper.update(comment);
 	}
 
 	@Override

--- a/application/src/main/java/core/application/movies/repositories/mapper/CommentDislikeMapper.java
+++ b/application/src/main/java/core/application/movies/repositories/mapper/CommentDislikeMapper.java
@@ -1,0 +1,14 @@
+package core.application.movies.repositories.mapper;
+
+import java.util.UUID;
+
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface CommentDislikeMapper {
+	void save(Long commentId, UUID userId);
+
+	int countLikeByUser(Long commentId, UUID userId);
+
+	void delete(Long commentId, UUID userId);
+}

--- a/application/src/main/java/core/application/movies/repositories/mapper/CommentLikeMapper.java
+++ b/application/src/main/java/core/application/movies/repositories/mapper/CommentLikeMapper.java
@@ -1,0 +1,14 @@
+package core.application.movies.repositories.mapper;
+
+import java.util.UUID;
+
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface CommentLikeMapper {
+	void save(Long commentId, UUID userId);
+
+	int countLikeByUser(Long commentId, UUID userId);
+
+	void delete(Long commentId, UUID userId);
+}

--- a/application/src/main/java/core/application/movies/repositories/mapper/CommentMapper.java
+++ b/application/src/main/java/core/application/movies/repositories/mapper/CommentMapper.java
@@ -1,0 +1,28 @@
+package core.application.movies.repositories.mapper;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.apache.ibatis.annotations.Mapper;
+
+import core.application.movies.models.entities.CommentEntity;
+
+@Mapper
+public interface CommentMapper {
+	void save(String movieId, UUID userId, CommentEntity comment);
+
+	Optional<CommentEntity> findByCommentId(Long commentId);
+
+	List<CommentEntity> findByMovieId(String movieId);
+
+	List<CommentEntity> findByMovieIdOnDateDescend(String movieId);
+
+	List<CommentEntity> findByMovieIdOnLikeDescend(String movieId);
+
+	List<CommentEntity> findByMovieIdOnDislikeDescend(String movieId);
+
+	List<CommentEntity> selectAll();
+
+	void delete(Long commentId);
+}

--- a/application/src/main/java/core/application/movies/repositories/mapper/CommentMapper.java
+++ b/application/src/main/java/core/application/movies/repositories/mapper/CommentMapper.java
@@ -6,6 +6,7 @@ import java.util.UUID;
 
 import org.apache.ibatis.annotations.Mapper;
 
+import core.application.movies.models.dto.CommentRespDTO;
 import core.application.movies.models.entities.CommentEntity;
 
 @Mapper
@@ -14,15 +15,19 @@ public interface CommentMapper {
 
 	Optional<CommentEntity> findByCommentId(Long commentId);
 
-	List<CommentEntity> findByMovieId(String movieId);
+	Optional<CommentEntity> findByMovieIdAndUserId(String movieId, UUID userId);
 
-	List<CommentEntity> findByMovieIdOnDateDescend(String movieId);
+	List<CommentRespDTO> findByMovieId(String movieId, UUID userId, int offset);
 
-	List<CommentEntity> findByMovieIdOnLikeDescend(String movieId);
+	List<CommentRespDTO> findByMovieIdOnDateDescend(String movieId, UUID userId, int offset);
 
-	List<CommentEntity> findByMovieIdOnDislikeDescend(String movieId);
+	List<CommentRespDTO> findByMovieIdOnLikeDescend(String movieId, UUID userId, int offset);
+
+	List<CommentRespDTO> findByMovieIdOnDislikeDescend(String movieId, UUID userId, int offset);
 
 	List<CommentEntity> selectAll();
+
+	void update(CommentEntity comment);
 
 	void delete(Long commentId);
 }

--- a/application/src/main/java/core/application/movies/service/CommentService.java
+++ b/application/src/main/java/core/application/movies/service/CommentService.java
@@ -1,0 +1,105 @@
+package core.application.movies.service;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import core.application.movies.constant.CommentSort;
+import core.application.movies.exception.InvalidReactionException;
+import core.application.movies.exception.NotFoundCommentException;
+import core.application.movies.exception.WrongWriteCommentException;
+import core.application.movies.models.dto.CommentRespDTO;
+import core.application.movies.models.dto.CommentWriteReqDTO;
+import core.application.movies.models.entities.CommentEntity;
+import core.application.movies.repositories.CommentDislikeRepository;
+import core.application.movies.repositories.CommentLikeRepository;
+import core.application.movies.repositories.CommentRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class CommentService {
+	private final CommentRepository commentRepository;
+	private final CommentLikeRepository likeRepository;
+	private final CommentDislikeRepository dislikeRepository;
+
+	@Transactional(readOnly = true)
+	public List<CommentRespDTO> getComments(String movieId, int page, CommentSort sort, UUID userId) {
+		if (sort.equals(CommentSort.LIKE)) {
+			return commentRepository.findByMovieIdOnLikeDescend(movieId, userId, page * 10);
+		}
+
+		if (sort.equals(CommentSort.LATEST)) {
+			return commentRepository.findByMovieIdOnDateDescend(movieId, userId, page * 10);
+		}
+		return commentRepository.findByMovieIdOnDislikeDescend(movieId, userId, page * 10);
+	}
+
+	@Transactional
+	public CommentRespDTO writeCommentOnMovie(CommentWriteReqDTO writeReqDTO, UUID userId, String movieId) {
+		// 이미 작성한 기록이 있는지 확인한다.
+		if (commentRepository.existsByMovieIdAndUserId(movieId, userId)) {
+			throw new WrongWriteCommentException("한줄평은 1회 작성만 가능합니다.");
+		}
+
+		CommentEntity newComment = CommentEntity.of(writeReqDTO, movieId, userId);
+		CommentEntity save = commentRepository.saveNewComment(movieId, userId, newComment);
+		return CommentRespDTO.from(save);
+	}
+
+	@Transactional
+	public void incrementCommentLike(Long commentId, UUID userId) {
+		CommentEntity comment = commentRepository.findByCommentId(commentId)
+			.orElseThrow(() -> new NotFoundCommentException("존재하지 않는 한줄평입니다."));
+		if (likeRepository.isExistLike(commentId, userId)) {
+			throw new InvalidReactionException("이미 '좋아요'를 누른 한줄평입니다.");
+		}
+
+		comment.isLiked();
+		commentRepository.update(comment);
+		likeRepository.saveCommentLike(commentId, userId);
+	}
+
+	@Transactional
+	public void decrementCommentLike(Long commentId, UUID userId) {
+		CommentEntity comment = commentRepository.findByCommentId(commentId)
+			.orElseThrow(() -> new NotFoundCommentException("존재하지 않는 한줄평입니다."));
+		if (!likeRepository.isExistLike(commentId, userId)) {
+			throw new InvalidReactionException("'좋아요'를 누르지 않은 한줄평입니다.");
+		}
+
+		comment.cancelLike();
+		commentRepository.update(comment);
+		likeRepository.deleteCommentLike(commentId, userId);
+	}
+
+	@Transactional
+	public void incrementCommentDislike(Long commentId, UUID userId) {
+		CommentEntity comment = commentRepository.findByCommentId(commentId)
+			.orElseThrow(() -> new NotFoundCommentException("존재하지 않는 한줄평입니다."));
+		if (dislikeRepository.isExistDislike(commentId, userId)) {
+			throw new InvalidReactionException("이미 '싫어요'를 누른 한줄평입니다.");
+		}
+
+		comment.isDisliked();
+		commentRepository.update(comment);
+		dislikeRepository.saveCommentDislike(commentId, userId);
+	}
+
+	@Transactional
+	public void decrementCommentDislike(Long commentId, UUID userId) {
+		CommentEntity comment = commentRepository.findByCommentId(commentId)
+			.orElseThrow(() -> new NotFoundCommentException("존재하지 않는 한줄평입니다."));
+		if (!dislikeRepository.isExistDislike(commentId, userId)) {
+			throw new InvalidReactionException("'싫어요'를 누르지 않은 한줄평입니다.");
+		}
+
+		comment.cancelDislike();
+		commentRepository.update(comment);
+		dislikeRepository.deleteCommentDislike(commentId, userId);
+	}
+}

--- a/application/src/main/resources/mappers/movies/CommentDislikeMapper.xml
+++ b/application/src/main/resources/mappers/movies/CommentDislikeMapper.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="core.application.movies.repositories.mapper.CommentDislikeMapper">
+    <insert id="save">
+        insert into comment_dislike_table (comment_id, user_id)
+        values (#{commentId}, #{userId})
+    </insert>
+
+    <select id="countLikeByUser">
+        select count(*) from comment_dislike_table
+        where comment_id=#{commentId} and user_id=#{userId}
+    </select>
+
+    <delete id="delete">
+        delete from comment_dislike_table
+        where comment_id=#{commentId} and user_id=#{userId}
+    </delete>
+</mapper>

--- a/application/src/main/resources/mappers/movies/CommentLikeMapper.xml
+++ b/application/src/main/resources/mappers/movies/CommentLikeMapper.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="core.application.movies.repositories.mapper.CommentLikeMapper">
+    <insert id="save">
+        insert into comment_like_table (comment_id, user_id)
+        values (#{commentId}, #{userId})
+    </insert>
+
+    <select id="countLikeByUser">
+        select count(*) from comment_like_table
+        where comment_id=#{commentId} and user_id=#{userId}
+    </select>
+
+    <delete id="delete">
+        delete from comment_like_table
+        where comment_id=#{commentId} and user_id=#{userId}
+    </delete>
+</mapper>

--- a/application/src/main/resources/mappers/movies/CommentMapper.xml
+++ b/application/src/main/resources/mappers/movies/CommentMapper.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="core.application.movies.repositories.mapper.CommentMapper">
+    <insert id="save" useGeneratedKeys="true" keyProperty="comment.commentId">
+        insert into comment_table (content, `like`, dislike, rating, movie_id, user_id)
+        values (#{comment.content}, #{comment.like}, #{comment.dislike}, #{comment.rating}, #{movieId}, #{userId})
+    </insert>
+
+    <select id="findByCommentId" resultType="core.application.movies.models.entities.CommentEntity">
+        select comment_id, content, `like`, dislike, rating, movie_id, user_id, created_at
+        from comment_table
+        where comment_id=#{commentId}
+    </select>
+
+    <select id="findByMovieId" resultType="core.application.movies.models.entities.CommentEntity">
+        select comment_id, content, `like`, dislike, rating, movie_id, user_id, created_at
+        from comment_table
+        where movie_id=#{movieId}
+    </select>
+
+    <select id="findByMovieIdOnDateDescend" resultType="core.application.movies.models.entities.CommentEntity">
+        select comment_id, content, `like`, dislike, rating, movie_id, user_id, created_at
+        from comment_table
+        where movie_id=#{movieId}
+        order by created_at desc
+    </select>
+
+    <select id="findByMovieIdOnLikeDescend" resultType="core.application.movies.models.entities.CommentEntity">
+        select comment_id, content, `like`, dislike, rating, movie_id, user_id, created_at
+        from comment_table
+        where movie_id=#{movieId}
+        order by `like` desc
+    </select>
+
+    <select id="findByMovieIdOnDislikeDescend" resultType="core.application.movies.models.entities.CommentEntity">
+        select comment_id, content, `like`, dislike, rating, movie_id, user_id, created_at
+        from comment_table
+        where movie_id=#{movieId}
+        order by dislike desc
+    </select>
+
+
+    <select id="selectAll" resultType="core.application.movies.models.entities.CommentEntity">
+        select comment_id, content, `like`, dislike, rating, movie_id, user_id, created_at
+        from comment_table
+    </select>
+
+    <delete id="delete">
+        delete from comment_table
+        where comment_id=#{commentId}
+    </delete>
+</mapper>

--- a/application/src/main/resources/mappers/movies/CommentMapper.xml
+++ b/application/src/main/resources/mappers/movies/CommentMapper.xml
@@ -13,31 +13,109 @@
         where comment_id=#{commentId}
     </select>
 
-    <select id="findByMovieId" resultType="core.application.movies.models.entities.CommentEntity">
+    <select id="findByMovieIdAndUserId" resultType="core.application.movies.models.entities.CommentEntity">
         select comment_id, content, `like`, dislike, rating, movie_id, user_id, created_at
         from comment_table
-        where movie_id=#{movieId}
+        where movie_id=#{movieId} and user_id=#{userId}
     </select>
 
-    <select id="findByMovieIdOnDateDescend" resultType="core.application.movies.models.entities.CommentEntity">
-        select comment_id, content, `like`, dislike, rating, movie_id, user_id, created_at
-        from comment_table
+    <select id="findByMovieId" resultType="core.application.movies.models.dto.CommentRespDTO">
+        select c.comment_id, c.content, c.`like`, c.dislike, c.rating, c.movie_id, c.user_id, c.created_at,
+            case
+                when l.comment_like_id is not null then true
+                else false
+            end as isLiked,
+            case
+                when d.comment_dislike_id is not null then true
+                else false
+            end as isDisliked
+        from comment_table as c
+        left join
+            comment_like_table as l
+            on c.comment_id=l.comment_id
+            and l.user_id=#{userId}
+        left join
+            comment_dislike_table as d
+            on c.comment_id=d.comment_id
+            and d.user_id=#{userId}
         where movie_id=#{movieId}
+        limit 10
+        offset #{offset}
+    </select>
+
+    <select id="findByMovieIdOnDateDescend" resultType="core.application.movies.models.dto.CommentRespDTO">
+        select c.comment_id, c.content, c.`like`, c.dislike, c.rating, c.movie_id, c.user_id, c.created_at,
+            case
+                when l.comment_like_id is not null then true
+                else false
+            end as isLiked,
+            case
+                when d.comment_dislike_id is not null then true
+                else false
+            end as isDisliked
+        from comment_table as c
+        left join
+            comment_like_table as l
+            on c.comment_id=l.comment_id
+            and l.user_id=#{userId}
+        left join
+            comment_dislike_table as d
+            on c.comment_id=d.comment_id
+            and d.user_id=#{userId}
+            where movie_id=#{movieId}
         order by created_at desc
+        limit 10
+        offset #{offset}
     </select>
 
-    <select id="findByMovieIdOnLikeDescend" resultType="core.application.movies.models.entities.CommentEntity">
-        select comment_id, content, `like`, dislike, rating, movie_id, user_id, created_at
-        from comment_table
+    <select id="findByMovieIdOnLikeDescend" resultType="core.application.movies.models.dto.CommentRespDTO">
+        select c.comment_id, c.content, c.`like`, c.dislike, c.rating, c.movie_id, c.user_id, c.created_at,
+            case
+                when l.comment_like_id is not null then true
+                else false
+            end as isLiked,
+            case
+                when d.comment_dislike_id is not null then true
+                else false
+            end as isDisliked
+        from comment_table as c
+        left join
+            comment_like_table as l
+            on c.comment_id=l.comment_id
+            and l.user_id=#{userId}
+        left join
+            comment_dislike_table as d
+            on c.comment_id=d.comment_id
+            and d.user_id=#{userId}
         where movie_id=#{movieId}
         order by `like` desc
+        limit 10
+        offset #{offset}
     </select>
 
-    <select id="findByMovieIdOnDislikeDescend" resultType="core.application.movies.models.entities.CommentEntity">
-        select comment_id, content, `like`, dislike, rating, movie_id, user_id, created_at
-        from comment_table
+    <select id="findByMovieIdOnDislikeDescend" resultType="core.application.movies.models.dto.CommentRespDTO">
+        select c.comment_id, c.content, c.`like`, c.dislike, c.rating, c.movie_id, c.user_id, c.created_at,
+            case
+                when l.comment_like_id is not null then true
+                else false
+            end as isLiked,
+            case
+                when d.comment_dislike_id is not null then true
+                else false
+            end as isDisliked
+        from comment_table as c
+        left join
+            comment_like_table as l
+            on c.comment_id=l.comment_id
+            and l.user_id=#{userId}
+        left join
+            comment_dislike_table as d
+            on c.comment_id=d.comment_id
+        and d.user_id=#{userId}
         where movie_id=#{movieId}
         order by dislike desc
+        limit 10
+        offset #{offset}
     </select>
 
 
@@ -45,6 +123,15 @@
         select comment_id, content, `like`, dislike, rating, movie_id, user_id, created_at
         from comment_table
     </select>
+
+    <update id="update">
+        update comment_table
+        set content=#{content},
+            `like`=#{like},
+            dislike=#{dislike},
+            rating=#{rating}
+        where comment_id=#{commentId}
+    </update>
 
     <delete id="delete">
         delete from comment_table

--- a/application/src/test/java/core/application/movies/repository/CommentRepositoryTest.java
+++ b/application/src/test/java/core/application/movies/repository/CommentRepositoryTest.java
@@ -1,0 +1,207 @@
+package core.application.movies.repository;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import core.application.movies.constant.Genre;
+import core.application.movies.models.entities.CachedMovieEntity;
+import core.application.movies.models.entities.CommentEntity;
+import core.application.movies.repositories.CachedMovieRepository;
+import core.application.movies.repositories.CommentRepository;
+import core.application.users.models.entities.UserEntity;
+import core.application.users.models.entities.UserRole;
+import core.application.users.repositories.UserRepository;
+
+@SpringBootTest
+@Transactional
+public class CommentRepositoryTest {
+
+	@Autowired
+	private CommentRepository commentRepository;
+	@Autowired
+	private UserRepository userRepository;
+	@Autowired
+	private CachedMovieRepository movieRepository;
+	private CommentEntity comment;
+
+	@BeforeEach
+	public void setUp() {
+		UserEntity user = UserEntity.builder()
+			.userEmail("testEmail")
+			.userPw("test")
+			.role(UserRole.USER)
+			.alias("nickname")
+			.phoneNum("phone")
+			.userName("test")
+			.build();
+		userRepository.saveNewUser(user);
+
+		CachedMovieEntity movieEntity = new CachedMovieEntity(
+			"test",
+			"testTitle",
+			"posterUrl",
+			Genre.ACTION,
+			"2024-09-30",
+			"줄거리",
+			"122",
+			"마동석, 김무열",
+			"봉준호",
+			1L, 1L, 10L, 10L
+		);
+		movieRepository.saveNewMovie(movieEntity);
+
+		comment = CommentEntity.builder()
+			.content("내용")
+			.like(1)
+			.dislike(1)
+			.rating(10)
+			.movieId("test")
+			.userId(userRepository.findByUserEmail("testEmail").get().getUserId())
+			.build();
+	}
+
+	@Test
+	@DisplayName("한줄평 리뷰를 저장한다.")
+	public void save() {
+		// GIVEN
+
+		// WHEN
+		CommentEntity save = commentRepository.saveNewComment("test", comment.getUserId(), comment);
+
+		// THEN
+		assertThat(save).isNotNull();
+		assertThat(save.getContent()).isEqualTo(comment.getContent());
+		assertThat(save.getLike()).isEqualTo(comment.getLike());
+		assertThat(save.getDislike()).isEqualTo(comment.getDislike());
+		assertThat(save.getRating()).isEqualTo(comment.getRating());
+		assertThat(save.getMovieId()).isEqualTo(comment.getMovieId());
+		assertThat(save.getUserId()).isEqualTo(comment.getUserId());
+	}
+
+	@Test
+	@DisplayName("영화 ID로 조회한다.")
+	public void findByMovieId() {
+		// GIVEN
+		CommentEntity save1 = commentRepository.saveNewComment(comment.getMovieId(), comment.getUserId(),
+			comment);
+		CommentEntity comment2 = CommentEntity.builder()
+			.content("내용2")
+			.like(1)
+			.dislike(1)
+			.rating(10)
+			.movieId("test")
+			.userId(userRepository.findByUserEmail("testEmail").get().getUserId())
+			.build();
+		CommentEntity save2 = commentRepository.saveNewComment(comment2.getMovieId(), comment2.getUserId(),
+			comment2);
+
+		// WHEN
+		List<CommentEntity> find = commentRepository.findByMovieId(comment.getMovieId());
+
+		// THEN
+		assertThat(find.size()).isEqualTo(2);
+		for (CommentEntity commentEntity : find) {
+			assertThat(commentEntity.getMovieId()).isEqualTo("test");
+		}
+	}
+
+	@Test
+	@DisplayName("특정 영화의 한줄평을 시간순으로 조회한다.")
+	public void findByMovieIdOnDateDescend() {
+		// GIVEN
+		CommentEntity comment2 = CommentEntity.builder()
+			.content("내용2")
+			.like(1)
+			.dislike(1)
+			.rating(10)
+			.movieId("test")
+			.userId(userRepository.findByUserEmail("testEmail").get().getUserId())
+			.build();
+
+		// WHEN
+		List<CommentEntity> finds = commentRepository.findByMovieIdOnDateDescend("test");
+
+		// THEN
+		Instant later = finds.get(0).getCreatedAt();
+		for (CommentEntity find : finds) {
+			assertThat(later).isBeforeOrEqualTo(find.getCreatedAt());
+			later = find.getCreatedAt();
+		}
+	}
+
+	@Test
+	@DisplayName("특정 영화 한줄평을 좋아요 순으로 검색한다.")
+	public void testLikeOrder() {
+		// GIVEN
+		CommentEntity comment2 = CommentEntity.builder()
+			.content("내용2")
+			.like(100)
+			.dislike(1)
+			.rating(10)
+			.movieId("test")
+			.userId(userRepository.findByUserEmail("testEmail").get().getUserId())
+			.build();
+		commentRepository.saveNewComment(comment.getMovieId(), comment.getUserId(), comment);
+		commentRepository.saveNewComment(comment2.getMovieId(), comment2.getUserId(), comment2);
+
+		// WHEN
+		List<CommentEntity> finds = commentRepository.findByMovieIdOnLikeDescend("test");
+
+		// THEN
+		int more = finds.get(0).getLike();
+		for (CommentEntity find : finds) {
+			assertThat(more).isGreaterThanOrEqualTo(find.getLike());
+			more = find.getLike();
+		}
+	}
+
+	@Test
+	@DisplayName("특정 영화 한줄평을 싫어요 순으로 검색한다.")
+	public void testDislikeOrder() {
+		// GIVEN
+		CommentEntity comment2 = CommentEntity.builder()
+			.content("내용2")
+			.like(1)
+			.dislike(100)
+			.rating(10)
+			.movieId("test")
+			.userId(userRepository.findByUserEmail("testEmail").get().getUserId())
+			.build();
+		commentRepository.saveNewComment(comment.getMovieId(), comment.getUserId(), comment);
+		commentRepository.saveNewComment(comment2.getMovieId(), comment2.getUserId(), comment2);
+
+		// WHEN
+		List<CommentEntity> finds = commentRepository.findByMovieIdOnDislikeDescend("test");
+
+		// THEN
+		int more = finds.get(0).getDislike();
+		for (CommentEntity find : finds) {
+			assertThat(more).isGreaterThanOrEqualTo(find.getDislike());
+			more = find.getDislike();
+		}
+	}
+
+	@Test
+	@DisplayName("한줄평을 삭제한다.")
+	public void delete() {
+		// GIVEN
+		commentRepository.saveNewComment(comment.getMovieId(), comment.getUserId(), comment);
+
+		// WHEN
+		commentRepository.deleteComment(comment.getCommentId());
+
+		// THEN
+		Optional<CommentEntity> find = commentRepository.findByCommentId(comment.getCommentId());
+		assertThat(find).isEmpty();
+	}
+}

--- a/application/src/test/java/core/application/movies/service/CommentServiceTest.java
+++ b/application/src/test/java/core/application/movies/service/CommentServiceTest.java
@@ -1,0 +1,267 @@
+package core.application.movies.service;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import core.application.movies.constant.CommentSort;
+import core.application.movies.constant.Genre;
+import core.application.movies.models.dto.CommentRespDTO;
+import core.application.movies.models.dto.CommentWriteReqDTO;
+import core.application.movies.models.entities.CachedMovieEntity;
+import core.application.movies.models.entities.CommentEntity;
+import core.application.movies.repositories.CachedMovieRepository;
+import core.application.movies.repositories.CommentRepository;
+import core.application.users.models.entities.UserEntity;
+import core.application.users.models.entities.UserRole;
+import core.application.users.repositories.UserRepository;
+
+@SpringBootTest
+@Transactional
+public class CommentServiceTest {
+
+	@Autowired
+	private CommentService commentService;
+	@Autowired
+	private CommentRepository commentRepository;
+	@Autowired
+	private UserRepository userRepository;
+	@Autowired
+	private CachedMovieRepository movieRepository;
+	private List<UserEntity> users = new ArrayList<>();
+	private String movieId;
+
+	@BeforeEach
+	public void setUp() {
+		for (int i = 0; i < 10; i++) {
+			UserEntity testUser = UserEntity.builder()
+				.userEmail(String.valueOf(i))
+				.userPw("test")
+				.role(UserRole.USER)
+				.alias("nickname")
+				.phoneNum("phone")
+				.userName("test")
+				.build();
+			userRepository.saveNewUser(testUser);
+			users.add(userRepository.findByUserEmail(String.valueOf(i)).orElseThrow());
+		}
+
+		CachedMovieEntity movieEntity = new CachedMovieEntity(
+			"test",
+			"testTitle",
+			"posterUrl",
+			Genre.ACTION,
+			"2024-09-30",
+			"줄거리",
+			"122",
+			"마동석, 김무열",
+			"봉준호",
+			1L, 1L, 10L, 10L
+		);
+		CachedMovieEntity save = movieRepository.saveNewMovie(movieEntity);
+		movieId = save.getMovieId();
+	}
+
+	@Test
+	@DisplayName("한줄평을 작성한다.")
+	public void writeComment() {
+	    // GIVEN
+		CommentWriteReqDTO writeReqDTO = new CommentWriteReqDTO("한줄평 내용입니다.", 10);
+		UserEntity writer = users.get(0);
+
+		// WHEN
+		CommentRespDTO save = commentService.writeCommentOnMovie(writeReqDTO, writer.getUserId(), movieId);
+
+		// THEN
+		Optional<CommentEntity> find = commentRepository.findByCommentId(save.getCommentId());
+		assertThat(find).isPresent();
+		assertThat(find.get().getContent()).isEqualTo(writeReqDTO.getContent());
+		assertThat(find.get().getRating()).isEqualTo(writeReqDTO.getRating());
+	}
+
+	@Test
+	@DisplayName("영화의 한줄평을 최신순으로 불러온다.")
+	public void getLatestComments() throws InterruptedException {
+	    // GIVEN
+		for (int i = 0; i < 10; i++) {
+			CommentWriteReqDTO writeReqDTO = new CommentWriteReqDTO(i + "번째 한줄평", 10);
+			CommentRespDTO commentRespDTO = commentService.writeCommentOnMovie(writeReqDTO, users.get(i).getUserId(),
+				movieId);
+		}
+
+		// WHEN
+		List<CommentRespDTO> comments = commentService.getComments(movieId, 0, CommentSort.LATEST, null);
+
+		// THEN
+		assertThat(comments.size()).isEqualTo(10);
+		Instant later = comments.get(0).getCreatedAt();
+		for (int i = 1; i < comments.size(); i++) {
+			assertThat(later).isAfterOrEqualTo(comments.get(i).getCreatedAt());
+			later = comments.get(i).getCreatedAt();
+		}
+	}
+
+	@Test
+	@DisplayName("한줄평을 좋아요 순으로 불러온다.")
+	public void getMostLikedComments() {
+		// GIVEN
+		for (int i = 0; i < 10; i++) {
+			CommentWriteReqDTO writeReqDTO = new CommentWriteReqDTO(i + "번째 한줄평", 10);
+			CommentRespDTO commentRespDTO = commentService.writeCommentOnMovie(writeReqDTO, users.get(i).getUserId(),
+				movieId);
+			for (int j = 0; j < i; j++) {
+				UserEntity user = users.get(j);
+				commentService.incrementCommentLike(commentRespDTO.getCommentId(), user.getUserId());
+			}
+		}
+
+		// WHEN
+		List<CommentRespDTO> comments = commentService.getComments(movieId, 0, CommentSort.LIKE, null);
+
+		// THEN
+		int like = comments.get(0).getLike();
+		for (int i = 1; i < comments.size(); i++) {
+			assertThat(like).isGreaterThanOrEqualTo(comments.get(i).getLike());
+			like = comments.get(i).getLike();
+		}
+	}
+
+	@Test
+	@DisplayName("한줄평을 싫어요 순으로 불러온다.")
+	public void getMostDislikedComments() {
+		// GIVEN
+		for (int i = 0; i < 10; i++) {
+			CommentWriteReqDTO writeReqDTO = new CommentWriteReqDTO(i + "번째 한줄평", 10);
+			CommentRespDTO commentRespDTO = commentService.writeCommentOnMovie(writeReqDTO, users.get(i).getUserId(),
+				movieId);
+			for (int j = 0; j < i; j++) {
+				UserEntity user = users.get(j);
+				commentService.incrementCommentDislike(commentRespDTO.getCommentId(), user.getUserId());
+			}
+		}
+
+		// WHEN
+		List<CommentRespDTO> comments = commentService.getComments(movieId, 0, CommentSort.DISLIKE, null);
+
+		// THEN
+		int dislike = comments.get(0).getDislike();
+		for (int i = 1; i < comments.size(); i++) {
+			assertThat(dislike).isGreaterThanOrEqualTo(comments.get(i).getDislike());
+			dislike = comments.get(i).getDislike();
+		}
+	}
+
+	@Test
+	@DisplayName("한줄평에 좋아요을 누른다.")
+	public void likeComment() {
+	    // GIVEN
+		CommentWriteReqDTO writeReqDTO = new CommentWriteReqDTO("한줄평입니다.", 10);
+		UserEntity writer = users.get(0);
+		CommentRespDTO commentRespDTO = commentService.writeCommentOnMovie(writeReqDTO, writer.getUserId(), movieId);
+
+		// WHEN
+		commentService.incrementCommentLike(commentRespDTO.getCommentId(), writer.getUserId());
+
+		// THEN
+		CommentEntity comment = commentRepository.findByCommentId(commentRespDTO.getCommentId())
+			.orElseThrow(() -> new RuntimeException("존재하지 않은 한줄평입니다."));
+		assertThat(comment.getLike()).isEqualTo(1);
+	}
+
+	@Test
+	@DisplayName("좋아요를 취소한다.")
+	public void cancelLikeComment() {
+	    // GIVEN
+		CommentWriteReqDTO writeReqDTO = new CommentWriteReqDTO("한줄평입니다.", 10);
+		UserEntity writer = users.get(0);
+		CommentRespDTO commentRespDTO = commentService.writeCommentOnMovie(writeReqDTO, writer.getUserId(),
+			movieId);
+		commentService.incrementCommentLike(commentRespDTO.getCommentId(), users.get(1).getUserId());
+
+		// WHEN
+		commentService.decrementCommentLike(commentRespDTO.getCommentId(), users.get(1).getUserId());
+
+	    // THEN
+		CommentEntity comment = commentRepository.findByCommentId(commentRespDTO.getCommentId()).orElseThrow();
+		assertThat(comment.getLike()).isEqualTo(0);
+	}
+
+	@Test
+	@DisplayName("한줄평에 싫어요를 누른다.")
+	public void dislikeComment() {
+		// GIVEN
+		CommentWriteReqDTO writeReqDTO = new CommentWriteReqDTO("한줄평입니다.", 10);
+		UserEntity writer = users.get(0);
+		CommentRespDTO commentRespDTO = commentService.writeCommentOnMovie(writeReqDTO, writer.getUserId(), movieId);
+
+		// WHEN
+		commentService.incrementCommentDislike(commentRespDTO.getCommentId(), writer.getUserId());
+
+		// THEN
+		CommentEntity comment = commentRepository.findByCommentId(commentRespDTO.getCommentId())
+			.orElseThrow(() -> new RuntimeException("존재하지 않은 한줄평입니다."));
+		assertThat(comment.getDislike()).isEqualTo(1);
+	}
+
+	@Test
+	@DisplayName("싫어요를 취소한다.")
+	public void cancelDislikeComment() {
+		// GIVEN
+		CommentWriteReqDTO writeReqDTO = new CommentWriteReqDTO("한줄평입니다.", 10);
+		UserEntity writer = users.get(0);
+		CommentRespDTO commentRespDTO = commentService.writeCommentOnMovie(writeReqDTO, writer.getUserId(),
+			movieId);
+		commentService.incrementCommentDislike(commentRespDTO.getCommentId(), users.get(1).getUserId());
+
+		// WHEN
+		commentService.decrementCommentDislike(commentRespDTO.getCommentId(), users.get(1).getUserId());
+
+		// THEN
+		CommentEntity comment = commentRepository.findByCommentId(commentRespDTO.getCommentId()).orElseThrow();
+		assertThat(comment.getDislike()).isEqualTo(0);
+	}
+
+	@Test
+	@DisplayName("한줄평 조회 시, 좋아요와 싫어요를 누른 항목은 표시된다.")
+	public void displayTest() {
+	    // GIVEN
+		Set<Long> reactionCommentIds = new HashSet<>();
+		UserEntity user = users.get(0);
+		for (int i = 0; i < 10; i++) {
+			CommentWriteReqDTO writeReqDTO = new CommentWriteReqDTO(i + "번째 한줄평", 10);
+			CommentRespDTO commentRespDTO = commentService.writeCommentOnMovie(writeReqDTO, users.get(i).getUserId(),
+				movieId);
+			if (i < 5) {
+				commentService.incrementCommentLike(commentRespDTO.getCommentId(), user.getUserId());
+				commentService.incrementCommentDislike(commentRespDTO.getCommentId(), user.getUserId());
+				reactionCommentIds.add(commentRespDTO.getCommentId());
+			}
+		}
+
+	    // WHEN
+		List<CommentRespDTO> comments = commentService.getComments(movieId, 0, CommentSort.LIKE, user.getUserId());
+
+		// THEN
+		for (CommentRespDTO comment : comments) {
+			if (reactionCommentIds.contains(comment.getCommentId())) {
+				assertThat(comment.getIsLiked()).isTrue();
+				assertThat(comment.getIsDisliked()).isTrue();
+			} else {
+				assertThat(comment.getIsLiked()).isFalse();
+				assertThat(comment.getIsDisliked()).isFalse();
+			}
+		}
+	}
+}

--- a/assets/DDL.sql
+++ b/assets/DDL.sql
@@ -25,6 +25,12 @@ create table cached_movie_table
         primary key,
     title         varchar(100)     not null comment '영화 제목',
     poster_url    varchar(200)     not null comment '영화 포스터 이미지 url',
+    genre         varchar(50)      not null comment '영화 장르',
+    release_date  varchar(30)      not null comment '영화 개봉일',
+    plot          text             not null comment '영화 줄거리',
+    running_time  varchar(10)      not null comment '영화 상영시간',
+    actors        varchar(180)     not null comment '출연 배우 5명',
+    director      varchar(30)      not null comment '감독',
     dib_count     bigint default 0 not null comment '해당 영화가 찜으로 지정된 수',
     review_count  bigint default 0 not null comment '해당 영화에 달린 리뷰 포스팅 수',
     comment_count bigint default 0 not null comment '해당 영화에 달린 한줄평 수',
@@ -117,3 +123,16 @@ create table review_comment_table
 )
     comment '리뷰 댓글 테이블';
 
+create table comment_like_table (
+    comment_like_id bigint auto_increment primary key,
+    comment_id      bigint not null,
+    user_id         binary(16),
+    constraint foreign key (comment_id) references comment_table (comment_id),
+    constraint foreign key (user_id) references user_table (user_id));
+
+create table comment_dislike_table (
+    comment_dislike_id bigint auto_increment primary key,
+    comment_id      bigint not null,
+    user_id         binary(16),
+    constraint foreign key (comment_id) references comment_table (comment_id),
+    constraint foreign key (user_id) references user_table (user_id));


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->

한줄평에 관련된 기능을 구현했습니다. 좋아요와 싫어요를 쿠키로 구현하려다가 테이블로 분리하는 쪽으로 작성하였습니다.


## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->


- 한줄평 좋아요, 싫어요 테이블 추가
- 한줄평 관련 기능
  - 한줄평 조회
    - 조회한 유저에 따라 좋아요 or 싫어요를 누른 한줄평인지 구분 가능
  - 한줄평 작석
    - 이전에 작성한 영화의 한줄평이라면 작성 불가
  - 한줄평 좋아요
    - 기존에 좋아요를 누른 적이 있다면, 좋아요 불가
  - 한줄평 싫어요
    - 기존에 싫어요를 누른 적이 있다면, 싫어요 불가


## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->

movies 내에 `Repositories`, `dto` 패키지안의 클래스들이 다소 복잡해 이후 comment와 movie로 구분할 예정입니다.
