### PR TITLE
[Refactor] 한줄평 기능 JPA 마이그레이션

### DIFF
--- a/application/build.gradle
+++ b/application/build.gradle
@@ -33,6 +33,7 @@ dependencies {
 
     implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.3'
     implementation group: 'org.mybatis.dynamic-sql', name: 'mybatis-dynamic-sql', version: '1.5.2'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
     // Swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'

--- a/application/src/main/java/core/application/movies/controller/CommentController.java
+++ b/application/src/main/java/core/application/movies/controller/CommentController.java
@@ -1,8 +1,8 @@
 package core.application.movies.controller;
 
-import java.util.List;
 import java.util.UUID;
 
+import org.springframework.data.domain.Page;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.annotation.Validated;
@@ -44,9 +44,9 @@ public class CommentController {
 		@Parameter(name = "sortType", description = "정렬 타입", example = "LIKE")
 	})
 	@GetMapping("/{movieId}/comments")
-	public ApiResponse<List<CommentRespDTO>> getComments(@PathVariable String movieId,
+	public ApiResponse<Page<CommentRespDTO>> getComments(@PathVariable String movieId,
 		@RequestParam int page, @RequestParam String sortType, @AuthenticationPrincipal CustomUserDetails userDetails) {
-		List<CommentRespDTO> comments;
+		Page<CommentRespDTO> comments;
 		UUID userId;
 		if (userDetails == null) {
 			userId = null;
@@ -97,7 +97,8 @@ public class CommentController {
 
 	@Operation(summary = "한줄평 좋아요 취소")
 	@DeleteMapping("/{movieId}/comments/{commentId}/like")
-	public ApiResponse<Message> decrementCommentLike(@PathVariable Long commentId, @AuthenticationPrincipal CustomUserDetails userDetails) {
+	public ApiResponse<Message> decrementCommentLike(@PathVariable Long commentId,
+		@AuthenticationPrincipal CustomUserDetails userDetails) {
 		UUID userId = userDetails.getUserId();
 		commentService.decrementCommentLike(commentId, userId);
 		return ApiResponse.onDeleteSuccess(Message.createMessage("한줄평 좋아요 취소 성공"));

--- a/application/src/main/java/core/application/movies/controller/CommentController.java
+++ b/application/src/main/java/core/application/movies/controller/CommentController.java
@@ -65,7 +65,7 @@ public class CommentController {
 
 	@Operation(summary = "한줄평 작성")
 	@PostMapping("/{movieId}/comments")
-	public ApiResponse<CommentRespDTO> writeComment(@PathVariable String movieId,
+	public ApiResponse<CommentRespDTO> writeComment(@PathVariable("movieId") String movieId,
 		@RequestBody @Validated CommentWriteReqDTO writeReqDTO, BindingResult bindingResult,
 		@AuthenticationPrincipal CustomUserDetails userDetails) {
 		if (bindingResult.hasErrors()) {
@@ -79,7 +79,8 @@ public class CommentController {
 
 	@Operation(summary = "한줄평 삭제")
 	@DeleteMapping("/{movieId}/comments/{commentId}")
-	public ApiResponse<Message> deleteComment(@PathVariable String movieId, @PathVariable String commentId,
+	public ApiResponse<Message> deleteComment(@PathVariable("movieId") String movieId,
+		@PathVariable("commentId") String commentId,
 		@AuthenticationPrincipal CustomUserDetails userDetails) {
 		UUID userId = userDetails.getUserId();
 		commentService.deleteCommentOnMovie(movieId, userId, Long.parseLong(commentId));
@@ -88,7 +89,7 @@ public class CommentController {
 
 	@Operation(summary = "한줄평 좋아요")
 	@PostMapping("/{movieId}/comments/{commentId}/like")
-	public ApiResponse<Message> incrementCommentLike(@PathVariable Long commentId,
+	public ApiResponse<Message> incrementCommentLike(@PathVariable("commentId") Long commentId,
 		@AuthenticationPrincipal CustomUserDetails userDetails) {
 		UUID userId = userDetails.getUserId();
 		commentService.incrementCommentLike(commentId, userId);
@@ -97,7 +98,7 @@ public class CommentController {
 
 	@Operation(summary = "한줄평 좋아요 취소")
 	@DeleteMapping("/{movieId}/comments/{commentId}/like")
-	public ApiResponse<Message> decrementCommentLike(@PathVariable Long commentId,
+	public ApiResponse<Message> decrementCommentLike(@PathVariable("commentId") Long commentId,
 		@AuthenticationPrincipal CustomUserDetails userDetails) {
 		UUID userId = userDetails.getUserId();
 		commentService.decrementCommentLike(commentId, userId);
@@ -106,7 +107,7 @@ public class CommentController {
 
 	@Operation(summary = "한줄평 싫어요")
 	@PostMapping("/{movieId}/comments/{commentId}/dislike")
-	public ApiResponse<Message> incrementCommentDislike(@PathVariable Long commentId,
+	public ApiResponse<Message> incrementCommentDislike(@PathVariable("commentId") Long commentId,
 		@AuthenticationPrincipal CustomUserDetails userDetails) {
 		UUID userId = userDetails.getUserId();
 		commentService.incrementCommentDislike(commentId, userId);
@@ -115,7 +116,7 @@ public class CommentController {
 
 	@Operation(summary = "한줄평 싫어요 취소")
 	@DeleteMapping("/{movieId}/comments/{commentId}/dislike")
-	public ApiResponse<Message> decrementCommentDislike(@PathVariable Long commentId,
+	public ApiResponse<Message> decrementCommentDislike(@PathVariable("commentId") Long commentId,
 		@AuthenticationPrincipal CustomUserDetails userDetails) {
 		UUID userId = userDetails.getUserId();
 		commentService.decrementCommentDislike(commentId, userId);

--- a/application/src/main/java/core/application/movies/controller/CommentController.java
+++ b/application/src/main/java/core/application/movies/controller/CommentController.java
@@ -44,8 +44,8 @@ public class CommentController {
 		@Parameter(name = "sortType", description = "정렬 타입", example = "LIKE")
 	})
 	@GetMapping("/{movieId}/comments")
-	public ApiResponse<Page<CommentRespDTO>> getComments(@PathVariable String movieId,
-		@RequestParam int page, @RequestParam String sortType, @AuthenticationPrincipal CustomUserDetails userDetails) {
+	public ApiResponse<Page<CommentRespDTO>> getComments(@PathVariable("movieId") String movieId,
+		@RequestParam("page") int page, @RequestParam("sortType") String sortType, @AuthenticationPrincipal CustomUserDetails userDetails) {
 		Page<CommentRespDTO> comments;
 		UUID userId;
 		if (userDetails == null) {

--- a/application/src/main/java/core/application/movies/models/entities/CachedMovieEntity.java
+++ b/application/src/main/java/core/application/movies/models/entities/CachedMovieEntity.java
@@ -1,5 +1,8 @@
 package core.application.movies.models.entities;
 
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -12,10 +15,13 @@ import lombok.ToString;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @ToString
+@Entity
+@Table(name = "cached_movie_table")
 public class CachedMovieEntity {
 	/**
 	 * {@code 알파벳}-{@code 숫자} 형태 {@code (KMDB 영화 ID 형태)}
 	 */
+	@Id
 	private String movieId;
 	private String title;
 	private String posterUrl;

--- a/application/src/main/java/core/application/movies/models/entities/CommentDislike.java
+++ b/application/src/main/java/core/application/movies/models/entities/CommentDislike.java
@@ -1,0 +1,41 @@
+package core.application.movies.models.entities;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "comment_dislike_table")
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CommentDislike {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long commentDislikeId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "comment_id")
+    private CommentEntity comment;
+
+    private UUID userId;
+
+    public static CommentDislike of(CommentEntity comment, UUID userId) {
+        return CommentDislike.builder()
+                .comment(comment)
+                .userId(userId)
+                .build();
+    }
+}

--- a/application/src/main/java/core/application/movies/models/entities/CommentEntity.java
+++ b/application/src/main/java/core/application/movies/models/entities/CommentEntity.java
@@ -1,29 +1,41 @@
 package core.application.movies.models.entities;
 
+import core.application.movies.models.dto.request.CommentWriteReqDTO;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import java.time.Instant;
 import java.util.UUID;
-
-import core.application.movies.models.dto.request.CommentWriteReqDTO;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
+import org.hibernate.annotations.CreationTimestamp;
 
 @Getter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @ToString
+@Entity
+@Table(name = "comment_table")
 public class CommentEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long commentId;
 	private String content;
+	@Column(name = "`like`")
 	private int like;
 	private int dislike;
 	private int rating;
 	private String movieId;     // 영화 API 에 따라 달라질 수 있음.
 	private UUID userId;
+	@CreationTimestamp
 	private Instant createdAt;
 
 	public static CommentEntity of(CommentWriteReqDTO comment, String movieId, UUID userId) {

--- a/application/src/main/java/core/application/movies/models/entities/CommentLike.java
+++ b/application/src/main/java/core/application/movies/models/entities/CommentLike.java
@@ -1,0 +1,41 @@
+package core.application.movies.models.entities;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@Table(name = "comment_like_table")
+public class CommentLike {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long commentLikeId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "comment_id")
+    private CommentEntity comment;
+
+    private UUID userId;
+
+    public static CommentLike of(CommentEntity comment, UUID userId) {
+        return CommentLike.builder()
+                .comment(comment)
+                .userId(userId)
+                .build();
+    }
+}

--- a/application/src/main/java/core/application/movies/repositories/comment/CommentDislikeRepository.java
+++ b/application/src/main/java/core/application/movies/repositories/comment/CommentDislikeRepository.java
@@ -1,0 +1,12 @@
+package core.application.movies.repositories.comment;
+
+import java.util.UUID;
+
+public interface CommentDislikeRepository {
+
+    void saveCommentDislike(Long commentId, UUID userId);
+
+    boolean isExistDislike(Long commentId, UUID userId);
+
+    void deleteCommentDislike(Long commentId, UUID userId);
+}

--- a/application/src/main/java/core/application/movies/repositories/comment/CommentLikeRepository.java
+++ b/application/src/main/java/core/application/movies/repositories/comment/CommentLikeRepository.java
@@ -1,0 +1,12 @@
+package core.application.movies.repositories.comment;
+
+import java.util.UUID;
+
+public interface CommentLikeRepository {
+
+    void saveCommentLike(Long commentId, UUID userId);
+
+    boolean isExistLike(Long commentId, UUID userId);
+
+    void deleteCommentLike(Long commentId, UUID userId);
+}

--- a/application/src/main/java/core/application/movies/repositories/comment/CommentRepository.java
+++ b/application/src/main/java/core/application/movies/repositories/comment/CommentRepository.java
@@ -53,42 +53,31 @@ public interface CommentRepository {
 	 * @see #findByMovieIdOnLikeDescend(String, UUID, int)
 	 * @see #findByMovieIdOnDislikeDescend(String, UUID, int)
 	 */
-	List<CommentRespDTO> findByMovieId(String movieId, UUID userId, int offset);
+	Page<CommentRespDTO> findByMovieId(String movieId, UUID userId, int page);
 
 	/**
-	 * Mybatis 리포지토리 구현체가 특정 영화에 달린 한줄평 댓글을 최신순으로 검색
+	 * 특정 영화에 달린 한줄평 댓글을 최신순으로 검색
 	 *
 	 * @param movieId 검색할 영화 ID
 	 * @return {@link List}{@code <}{@link CommentEntity}{@code >}
 	 */
-	List<CommentRespDTO> findByMovieIdOnDateDescend(String movieId, UUID userId, int offset);
+	Page<CommentRespDTO> findByMovieIdOnDateDescend(String movieId, UUID userId, int page);
 
 	/**
-	 * Mybatis 리포지토리 구현체가 특정 영화에 달린 한줄평 댓글을 좋아요 순으로 검색
+	 * 특정 영화에 달린 한줄평 댓글을 좋아요 순으로 검색
 	 *
 	 * @param movieId 검색할 영화 ID
 	 * @return {@link List}{@code <}{@link CommentEntity}{@code >}
 	 */
-	List<CommentRespDTO> findByMovieIdOnLikeDescend(String movieId, UUID userId, int offset);
+	Page<CommentRespDTO> findByMovieIdOnLikeDescend(String movieId, UUID userId, int page);
 
 	/**
-	 * Mybatis 리포지토리 구현체가 특정 영화에 달린 한줄평 댓글을 싫어요 순으로 검색
+	 * 특정 영화에 달린 한줄평 댓글을 싫어요 순으로 검색
 	 *
 	 * @param movieId 검색할 영화 ID
 	 * @return {@link List}{@code <}{@link CommentEntity}{@code >}
 	 */
-	List<CommentRespDTO> findByMovieIdOnDislikeDescend(String movieId, UUID userId, int offset);
-
-
-	/**
-	 * JPA 리포지토리 구현체가 영화에 대한 한줄평 검색
-	 *
-	 * @param movieId 영화 ID
-	 * @param userId 유저 ID
-	 * @param pageable 페이지, 정렬 조건
-	 * @return 정렬된 해당 페이지의 한줄평
-	 */
-	Page<CommentRespDTO> findByMovieIdOrderBy(String movieId,  UUID userId, Pageable pageable);
+	Page<CommentRespDTO> findByMovieIdOnDislikeDescend(String movieId, UUID userId, int page);
 
 	/**
 	 * DB 의 모든 한줄평 댓글을 검색
@@ -97,13 +86,6 @@ public interface CommentRepository {
 	 */
 	List<CommentEntity> selectAll();
 	//</editor-fold>
-
-	/**
-	 * 해당 영화의 한줄평 개수 반환
-	 * @param movieId 영화 ID
-	 * @return 해당 영화의 한줄평 총 개수
-	 */
-	long countByMovieId(String movieId);
 
 	// UPDATE
 

--- a/application/src/main/java/core/application/movies/repositories/comment/CommentRepository.java
+++ b/application/src/main/java/core/application/movies/repositories/comment/CommentRepository.java
@@ -6,6 +6,8 @@ import java.util.UUID;
 
 import core.application.movies.models.dto.response.CommentRespDTO;
 import core.application.movies.models.entities.CommentEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 /**
  * {@code COMMENT_TABLE} 과 관련된 {@code Repository}
@@ -34,6 +36,12 @@ public interface CommentRepository {
 	 */
 	Optional<CommentEntity> findByCommentId(Long commentId);
 
+	/**
+	 *
+	 * @param movieId 영화 ID
+	 * @param userId 유저 ID
+	 * @return 사용자가 해당 영화에 한줄평을 작성한 기록이 있는지 확인
+	 */
 	Boolean existsByMovieIdAndUserId(String movieId, UUID userId);
 
 	/**
@@ -48,7 +56,7 @@ public interface CommentRepository {
 	List<CommentRespDTO> findByMovieId(String movieId, UUID userId, int offset);
 
 	/**
-	 * 특정 영화에 달린 한줄평 댓글을 최신순으로 검색
+	 * Mybatis 리포지토리 구현체가 특정 영화에 달린 한줄평 댓글을 최신순으로 검색
 	 *
 	 * @param movieId 검색할 영화 ID
 	 * @return {@link List}{@code <}{@link CommentEntity}{@code >}
@@ -56,7 +64,7 @@ public interface CommentRepository {
 	List<CommentRespDTO> findByMovieIdOnDateDescend(String movieId, UUID userId, int offset);
 
 	/**
-	 * 특정 영화에 달린 한줄평 댓글을 좋아요 순으로 검색
+	 * Mybatis 리포지토리 구현체가 특정 영화에 달린 한줄평 댓글을 좋아요 순으로 검색
 	 *
 	 * @param movieId 검색할 영화 ID
 	 * @return {@link List}{@code <}{@link CommentEntity}{@code >}
@@ -64,12 +72,23 @@ public interface CommentRepository {
 	List<CommentRespDTO> findByMovieIdOnLikeDescend(String movieId, UUID userId, int offset);
 
 	/**
-	 * 특정 영화에 달린 한줄평 댓글을 싫어요 순으로 검색
+	 * Mybatis 리포지토리 구현체가 특정 영화에 달린 한줄평 댓글을 싫어요 순으로 검색
 	 *
 	 * @param movieId 검색할 영화 ID
 	 * @return {@link List}{@code <}{@link CommentEntity}{@code >}
 	 */
 	List<CommentRespDTO> findByMovieIdOnDislikeDescend(String movieId, UUID userId, int offset);
+
+
+	/**
+	 * JPA 리포지토리 구현체가 영화에 대한 한줄평 검색
+	 *
+	 * @param movieId 영화 ID
+	 * @param userId 유저 ID
+	 * @param pageable 페이지, 정렬 조건
+	 * @return 정렬된 해당 페이지의 한줄평
+	 */
+	Page<CommentRespDTO> findByMovieIdOrderBy(String movieId,  UUID userId, Pageable pageable);
 
 	/**
 	 * DB 의 모든 한줄평 댓글을 검색
@@ -78,6 +97,13 @@ public interface CommentRepository {
 	 */
 	List<CommentEntity> selectAll();
 	//</editor-fold>
+
+	/**
+	 * 해당 영화의 한줄평 개수 반환
+	 * @param movieId 영화 ID
+	 * @return 해당 영화의 한줄평 총 개수
+	 */
+	long countByMovieId(String movieId);
 
 	// UPDATE
 

--- a/application/src/main/java/core/application/movies/repositories/comment/jpa/CommentDislikeRepositoryJPAImpl.java
+++ b/application/src/main/java/core/application/movies/repositories/comment/jpa/CommentDislikeRepositoryJPAImpl.java
@@ -1,0 +1,30 @@
+package core.application.movies.repositories.comment.jpa;
+
+import core.application.movies.repositories.comment.CommentDislikeRepository;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+@Profile("jpa")
+public class CommentDislikeRepositoryJPAImpl implements CommentDislikeRepository {
+
+    private final JpaCommentDislikeRepository jpaRepository;
+
+    @Override
+    public void saveCommentDislike(Long commentId, UUID userId) {
+        jpaRepository.saveDisLike(commentId, userId);
+    }
+
+    @Override
+    public boolean isExistDislike(Long commentId, UUID userId) {
+        return jpaRepository.existsByComment_CommentIdAndUserId(commentId, userId);
+    }
+
+    @Override
+    public void deleteCommentDislike(Long commentId, UUID userId) {
+        jpaRepository.deleteByComment_CommentIdAndUserId(commentId, userId);
+    }
+}

--- a/application/src/main/java/core/application/movies/repositories/comment/jpa/CommentLikeRepositoryJPAImpl.java
+++ b/application/src/main/java/core/application/movies/repositories/comment/jpa/CommentLikeRepositoryJPAImpl.java
@@ -1,0 +1,30 @@
+package core.application.movies.repositories.comment.jpa;
+
+import core.application.movies.repositories.comment.CommentLikeRepository;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+@Profile("jpa")
+public class CommentLikeRepositoryJPAImpl implements CommentLikeRepository {
+
+    private final JpaCommentLikeRepository jpaRepository;
+
+    @Override
+    public void saveCommentLike(Long commentId, UUID userId) {
+        jpaRepository.saveLike(commentId, userId);
+    }
+
+    @Override
+    public boolean isExistLike(Long commentId, UUID userId) {
+        return jpaRepository.existsByComment_CommentIdAndUserId(commentId, userId);
+    }
+
+    @Override
+    public void deleteCommentLike(Long commentId, UUID userId) {
+        jpaRepository.deleteByComment_CommentIdAndUserId(commentId, userId);
+    }
+}

--- a/application/src/main/java/core/application/movies/repositories/comment/jpa/CommentRepositoryJPAImpl.java
+++ b/application/src/main/java/core/application/movies/repositories/comment/jpa/CommentRepositoryJPAImpl.java
@@ -9,7 +9,9 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Profile;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -35,38 +37,31 @@ public class CommentRepositoryJPAImpl implements CommentRepository {
     }
 
     @Override
-    public List<CommentRespDTO> findByMovieId(String movieId, UUID userId, int page) {
-        return List.of();
+    public Page<CommentRespDTO> findByMovieId(String movieId, UUID userId, int page) {
+        return jpaRepository.findByMovieId(movieId, userId, PageRequest.of(page, 10));
     }
 
     @Override
-    public List<CommentRespDTO> findByMovieIdOnDateDescend(String movieId, UUID userId, int page) {
-        return List.of();
+    public Page<CommentRespDTO> findByMovieIdOnDateDescend(String movieId, UUID userId, int page) {
+        Pageable pageable = PageRequest.of(page, 10, Sort.by(Sort.Direction.DESC, "createdAt"));
+        return jpaRepository.findByMovieIdOrderBy(movieId, userId, pageable);
     }
 
     @Override
-    public List<CommentRespDTO> findByMovieIdOnLikeDescend(String movieId, UUID userId, int offset) {
-        return List.of();
+    public Page<CommentRespDTO> findByMovieIdOnLikeDescend(String movieId, UUID userId, int page) {
+        Pageable pageable = PageRequest.of(page, 10, Sort.by(Sort.Direction.DESC, "like"));
+        return jpaRepository.findByMovieIdOrderBy(movieId, userId, pageable);
     }
 
     @Override
-    public List<CommentRespDTO> findByMovieIdOnDislikeDescend(String movieId, UUID userId, int offset) {
-        return List.of();
-    }
-
-    @Override
-    public Page<CommentRespDTO> findByMovieIdOrderBy(String movieId, UUID userId, Pageable pageable) {
+    public Page<CommentRespDTO> findByMovieIdOnDislikeDescend(String movieId, UUID userId, int page) {
+        Pageable pageable = PageRequest.of(page, 10, Sort.by(Sort.Direction.DESC, "dislike"));
         return jpaRepository.findByMovieIdOrderBy(movieId, userId, pageable);
     }
 
     @Override
     public List<CommentEntity> selectAll() {
         return jpaRepository.findAll();
-    }
-
-    @Override
-    public long countByMovieId(String movieId) {
-        return 0;
     }
 
     @Override

--- a/application/src/main/java/core/application/movies/repositories/comment/jpa/CommentRepositoryJPAImpl.java
+++ b/application/src/main/java/core/application/movies/repositories/comment/jpa/CommentRepositoryJPAImpl.java
@@ -1,0 +1,81 @@
+package core.application.movies.repositories.comment.jpa;
+
+import core.application.movies.models.dto.response.CommentRespDTO;
+import core.application.movies.models.entities.CommentEntity;
+import core.application.movies.repositories.comment.CommentRepository;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+@Profile("jpa")
+public class CommentRepositoryJPAImpl implements CommentRepository {
+
+    private final JpaCommentRepository jpaRepository;
+
+    @Override
+    public CommentEntity saveNewComment(String movieId, UUID userId, CommentEntity comment) {
+        return jpaRepository.save(comment);
+    }
+
+    @Override
+    public Optional<CommentEntity> findByCommentId(Long commentId) {
+        return jpaRepository.findById(commentId);
+    }
+
+    @Override
+    public Boolean existsByMovieIdAndUserId(String movieId, UUID userId) {
+        return jpaRepository.existsByMovieIdAndUserId(movieId, userId);
+    }
+
+    @Override
+    public List<CommentRespDTO> findByMovieId(String movieId, UUID userId, int page) {
+        return List.of();
+    }
+
+    @Override
+    public List<CommentRespDTO> findByMovieIdOnDateDescend(String movieId, UUID userId, int page) {
+        return List.of();
+    }
+
+    @Override
+    public List<CommentRespDTO> findByMovieIdOnLikeDescend(String movieId, UUID userId, int offset) {
+        return List.of();
+    }
+
+    @Override
+    public List<CommentRespDTO> findByMovieIdOnDislikeDescend(String movieId, UUID userId, int offset) {
+        return List.of();
+    }
+
+    @Override
+    public Page<CommentRespDTO> findByMovieIdOrderBy(String movieId, UUID userId, Pageable pageable) {
+        return jpaRepository.findByMovieIdOrderBy(movieId, userId, pageable);
+    }
+
+    @Override
+    public List<CommentEntity> selectAll() {
+        return jpaRepository.findAll();
+    }
+
+    @Override
+    public long countByMovieId(String movieId) {
+        return 0;
+    }
+
+    @Override
+    public void update(CommentEntity comment) {
+        jpaRepository.save(comment);
+    }
+
+    @Override
+    public void deleteComment(Long commentId) {
+        jpaRepository.deleteById(commentId);
+    }
+}

--- a/application/src/main/java/core/application/movies/repositories/comment/jpa/JpaCommentDislikeRepository.java
+++ b/application/src/main/java/core/application/movies/repositories/comment/jpa/JpaCommentDislikeRepository.java
@@ -1,0 +1,18 @@
+package core.application.movies.repositories.comment.jpa;
+
+import core.application.movies.models.entities.CommentDislike;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+
+public interface JpaCommentDislikeRepository extends JpaRepository<CommentDislike, Long> {
+
+    @Modifying
+    @Query(value = "insert into comment_dislike_table(comment_id, user_id) values (:commentId, :userId)", nativeQuery = true)
+    void saveDisLike(Long commentId, UUID userId);
+
+    Boolean existsByComment_CommentIdAndUserId(Long commentId, UUID userId);
+
+    void deleteByComment_CommentIdAndUserId(Long commentId, UUID userId);
+}

--- a/application/src/main/java/core/application/movies/repositories/comment/jpa/JpaCommentLikeRepository.java
+++ b/application/src/main/java/core/application/movies/repositories/comment/jpa/JpaCommentLikeRepository.java
@@ -1,0 +1,19 @@
+package core.application.movies.repositories.comment.jpa;
+
+import core.application.movies.models.entities.CommentLike;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+
+public interface JpaCommentLikeRepository extends JpaRepository<CommentLike, Long> {
+
+    @Modifying
+    @Query(value = "insert into comment_like_table(comment_id, user_id) values (:commentId, :userId)",
+    nativeQuery = true)
+    void saveLike(Long commentId, UUID userId);
+
+    Boolean existsByComment_CommentIdAndUserId(Long commentId, UUID userId);
+
+    void deleteByComment_CommentIdAndUserId(Long commentId, UUID userId);
+}

--- a/application/src/main/java/core/application/movies/repositories/comment/jpa/JpaCommentRepository.java
+++ b/application/src/main/java/core/application/movies/repositories/comment/jpa/JpaCommentRepository.java
@@ -1,0 +1,31 @@
+package core.application.movies.repositories.comment.jpa;
+
+import core.application.movies.models.dto.response.CommentRespDTO;
+import core.application.movies.models.entities.CommentEntity;
+import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface JpaCommentRepository extends JpaRepository<CommentEntity, Long> {
+    Boolean existsByMovieIdAndUserId(String movieId, UUID userId);
+
+    @Query("SELECT new core.application.movies.models.dto.response.CommentRespDTO(c.commentId, c.content, c.like, c.dislike, c.rating, c.movieId, c.userId, c.createdAt, " +
+            "CASE WHEN l.commentLikeId IS NOT NULL THEN true ELSE false END, " +
+            "CASE WHEN d.commentDislikeId IS NOT NULL THEN true ELSE false END) " +
+            "FROM CommentEntity c " +
+            "LEFT JOIN CommentLike l ON c.commentId = l.comment.commentId AND l.userId = :userId " +
+            "LEFT JOIN CommentDislike d ON c.commentId = d.comment.commentId AND d.userId = :userId " +
+            "WHERE c.movieId = :movieId")
+    Page<CommentRespDTO> findByMovieId(String movieId, UUID userId, Pageable pageable);
+
+    @Query("SELECT new core.application.movies.models.dto.response.CommentRespDTO(c.commentId, c.content, c.like, c.dislike, c.rating, c.movieId, c.userId, c.createdAt, " +
+            "CASE WHEN l.commentLikeId IS NOT NULL THEN true ELSE false END, " +
+            "CASE WHEN d.commentDislikeId IS NOT NULL THEN true ELSE false END) " +
+            "FROM CommentEntity c " +
+            "LEFT JOIN CommentLike l ON c.commentId = l.comment.commentId AND l.userId = :userId " +
+            "LEFT JOIN CommentDislike d ON c.commentId = d.comment.commentId AND d.userId = :userId " +
+            "WHERE c.movieId = :movieId")
+    Page<CommentRespDTO> findByMovieIdOrderBy(String movieId, UUID userId, Pageable pageable);
+}

--- a/application/src/main/java/core/application/movies/repositories/comment/mybatis/MybatisCommentDislikeRepository.java
+++ b/application/src/main/java/core/application/movies/repositories/comment/mybatis/MybatisCommentDislikeRepository.java
@@ -2,14 +2,17 @@ package core.application.movies.repositories.comment.mybatis;
 
 import java.util.UUID;
 
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Repository;
 
+import core.application.movies.repositories.comment.CommentDislikeRepository;
 import core.application.movies.repositories.mapper.CommentDislikeMapper;
 import lombok.RequiredArgsConstructor;
 
 @Repository
 @RequiredArgsConstructor
-public class MybatisCommentDislikeRepository {
+@Profile("mybatis")
+public class MybatisCommentDislikeRepository implements CommentDislikeRepository {
 	private final CommentDislikeMapper commentDislikeMapper;
 
 	public void saveCommentDislike(Long commentId, UUID userId) {

--- a/application/src/main/java/core/application/movies/repositories/comment/mybatis/MybatisCommentDislikeRepository.java
+++ b/application/src/main/java/core/application/movies/repositories/comment/mybatis/MybatisCommentDislikeRepository.java
@@ -1,4 +1,4 @@
-package core.application.movies.repositories.comment;
+package core.application.movies.repositories.comment.mybatis;
 
 import java.util.UUID;
 
@@ -9,7 +9,7 @@ import lombok.RequiredArgsConstructor;
 
 @Repository
 @RequiredArgsConstructor
-public class CommentDislikeRepository {
+public class MybatisCommentDislikeRepository {
 	private final CommentDislikeMapper commentDislikeMapper;
 
 	public void saveCommentDislike(Long commentId, UUID userId) {

--- a/application/src/main/java/core/application/movies/repositories/comment/mybatis/MybatisCommentLikeRepository.java
+++ b/application/src/main/java/core/application/movies/repositories/comment/mybatis/MybatisCommentLikeRepository.java
@@ -2,14 +2,17 @@ package core.application.movies.repositories.comment.mybatis;
 
 import java.util.UUID;
 
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Repository;
 
+import core.application.movies.repositories.comment.CommentLikeRepository;
 import core.application.movies.repositories.mapper.CommentLikeMapper;
 import lombok.RequiredArgsConstructor;
 
 @Repository
 @RequiredArgsConstructor
-public class MybatisCommentLikeRepository {
+@Profile("mybatis")
+public class MybatisCommentLikeRepository implements CommentLikeRepository {
 	private final CommentLikeMapper commentLikeMapper;
 
 	public void saveCommentLike(Long commentId, UUID userId) {

--- a/application/src/main/java/core/application/movies/repositories/comment/mybatis/MybatisCommentLikeRepository.java
+++ b/application/src/main/java/core/application/movies/repositories/comment/mybatis/MybatisCommentLikeRepository.java
@@ -1,4 +1,4 @@
-package core.application.movies.repositories.comment;
+package core.application.movies.repositories.comment.mybatis;
 
 import java.util.UUID;
 
@@ -9,7 +9,7 @@ import lombok.RequiredArgsConstructor;
 
 @Repository
 @RequiredArgsConstructor
-public class CommentLikeRepository {
+public class MybatisCommentLikeRepository {
 	private final CommentLikeMapper commentLikeMapper;
 
 	public void saveCommentLike(Long commentId, UUID userId) {

--- a/application/src/main/java/core/application/movies/repositories/comment/mybatis/MybatisCommentRepository.java
+++ b/application/src/main/java/core/application/movies/repositories/comment/mybatis/MybatisCommentRepository.java
@@ -6,6 +6,8 @@ import java.util.UUID;
 
 import org.springframework.context.annotation.Profile;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
@@ -39,38 +41,41 @@ public class MybatisCommentRepository implements CommentRepository {
 	}
 
 	@Override
-	public List<CommentRespDTO> findByMovieId(String movieId, UUID userId, int offset) {
-		return commentMapper.findByMovieId(movieId, userId, offset);
+	public Page<CommentRespDTO> findByMovieId(String movieId, UUID userId, int page) {
+		Pageable pageable = PageRequest.of(page, 10);
+		int total = commentMapper.countByMovieId(movieId);
+		List<CommentRespDTO> find = commentMapper.findByMovieId(movieId, userId, page * 10);
+		return new PageImpl<>(find, pageable, total);
 	}
 
 	@Override
-	public List<CommentRespDTO> findByMovieIdOnDateDescend(String movieId, UUID userId, int offset) {
-		return commentMapper.findByMovieIdOnDateDescend(movieId, userId, offset);
+	public Page<CommentRespDTO> findByMovieIdOnDateDescend(String movieId, UUID userId, int page) {
+		Pageable pageable = PageRequest.of(page, 10);
+		int total = commentMapper.countByMovieId(movieId);
+		List<CommentRespDTO> find = commentMapper.findByMovieIdOnDateDescend(movieId, userId, page * 10);
+		return new PageImpl<>(find, pageable, total);
 	}
 
 	@Override
-	public List<CommentRespDTO> findByMovieIdOnLikeDescend(String movieId, UUID userId, int offset) {
-		return commentMapper.findByMovieIdOnLikeDescend(movieId, userId, offset);
+	public Page<CommentRespDTO> findByMovieIdOnLikeDescend(String movieId, UUID userId, int page) {
+		Pageable pageable = PageRequest.of(page, 10);
+		int total = commentMapper.countByMovieId(movieId);
+		List<CommentRespDTO> find = commentMapper.findByMovieIdOnLikeDescend(movieId, userId, page * 10);
+		return new PageImpl<>(find, pageable, total);
 	}
 
 	@Override
-	public List<CommentRespDTO> findByMovieIdOnDislikeDescend(String movieId, UUID userId, int offset) {
-		return commentMapper.findByMovieIdOnDislikeDescend(movieId, userId, offset);
-	}
-
-	@Override
-	public Page<CommentRespDTO> findByMovieIdOrderBy(String movieId, UUID userId, Pageable pageable) {
-		return null;
+	public Page<CommentRespDTO> findByMovieIdOnDislikeDescend(String movieId, UUID userId, int page) {
+		Pageable pageable = PageRequest.of(page, 10);
+		int total = commentMapper.countByMovieId(movieId);
+		List<CommentRespDTO> find = commentMapper.findByMovieIdOnDislikeDescend(movieId, userId,
+			page * 10);
+		return new PageImpl<>(find, pageable, total);
 	}
 
 	@Override
 	public List<CommentEntity> selectAll() {
 		return commentMapper.selectAll();
-	}
-
-	@Override
-	public long countByMovieId(String movieId) {
-		return commentMapper.countByMovieId(movieId);
 	}
 
 	@Override

--- a/application/src/main/java/core/application/movies/repositories/comment/mybatis/MybatisCommentRepository.java
+++ b/application/src/main/java/core/application/movies/repositories/comment/mybatis/MybatisCommentRepository.java
@@ -1,19 +1,23 @@
 package core.application.movies.repositories.comment.mybatis;
 
-import core.application.movies.repositories.comment.CommentRepository;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+import org.springframework.context.annotation.Profile;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 import core.application.movies.models.dto.response.CommentRespDTO;
 import core.application.movies.models.entities.CommentEntity;
+import core.application.movies.repositories.comment.CommentRepository;
 import core.application.movies.repositories.mapper.CommentMapper;
 import lombok.RequiredArgsConstructor;
 
 @Repository
 @RequiredArgsConstructor
+@Profile("mybatis")
 public class MybatisCommentRepository implements CommentRepository {
 
 	private final CommentMapper commentMapper;
@@ -55,8 +59,18 @@ public class MybatisCommentRepository implements CommentRepository {
 	}
 
 	@Override
+	public Page<CommentRespDTO> findByMovieIdOrderBy(String movieId, UUID userId, Pageable pageable) {
+		return null;
+	}
+
+	@Override
 	public List<CommentEntity> selectAll() {
 		return commentMapper.selectAll();
+	}
+
+	@Override
+	public long countByMovieId(String movieId) {
+		return commentMapper.countByMovieId(movieId);
 	}
 
 	@Override

--- a/application/src/main/java/core/application/movies/repositories/comment/mybatis/MybatisCommentRepository.java
+++ b/application/src/main/java/core/application/movies/repositories/comment/mybatis/MybatisCommentRepository.java
@@ -1,5 +1,6 @@
-package core.application.movies.repositories.comment;
+package core.application.movies.repositories.comment.mybatis;
 
+import core.application.movies.repositories.comment.CommentRepository;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -13,7 +14,7 @@ import lombok.RequiredArgsConstructor;
 
 @Repository
 @RequiredArgsConstructor
-public class CommentRepositoryImpl implements CommentRepository {
+public class MybatisCommentRepository implements CommentRepository {
 
 	private final CommentMapper commentMapper;
 

--- a/application/src/main/java/core/application/movies/repositories/mapper/CommentMapper.java
+++ b/application/src/main/java/core/application/movies/repositories/mapper/CommentMapper.java
@@ -27,6 +27,8 @@ public interface CommentMapper {
 
 	List<CommentEntity> selectAll();
 
+	int countByMovieId(String movieId);
+
 	void update(CommentEntity comment);
 
 	void delete(Long commentId);

--- a/application/src/main/resources/mappers/movies/CommentMapper.xml
+++ b/application/src/main/resources/mappers/movies/CommentMapper.xml
@@ -124,6 +124,11 @@
         from comment_table
     </select>
 
+    <select id="countByMovieId" resultType="int">
+        select count(*) from comment_table
+        where movie_id = #{movieId}
+    </select>
+
     <update id="update">
         update comment_table
         set content=#{content},

--- a/application/src/test/java/core/application/movies/repository/CommentRepositoryTest.java
+++ b/application/src/test/java/core/application/movies/repository/CommentRepositoryTest.java
@@ -118,13 +118,7 @@ public class CommentRepositoryTest {
 			comment2);
 
 		// WHEN
-		List<CommentRespDTO> finds;
-		if (commentRepository instanceof MybatisCommentRepository) {
-			finds = commentRepository.findByMovieId(comment.getMovieId(), null, 0);
-		} else {
-			finds = commentRepository.findByMovieIdOrderBy(comment.getMovieId(), null, PageRequest.of(0, 10))
-				.getContent();
-		}
+		List<CommentRespDTO> finds = commentRepository.findByMovieId(comment.getMovieId(), null, 0).getContent();
 
 		// THEN
 		assertThat(finds.size()).isEqualTo(2);
@@ -143,13 +137,7 @@ public class CommentRepositoryTest {
 		commentLikeRepository.saveCommentLike(comment.getCommentId(), userId);
 
 		// WHEN
-		List<CommentRespDTO> finds;
-		if (commentRepository instanceof MybatisCommentRepository) {
-			finds = commentRepository.findByMovieId(comment.getMovieId(), userId, 0);
-		} else {
-			finds = commentRepository.findByMovieIdOrderBy(comment.getMovieId(), userId, PageRequest.of(0, 10))
-				.getContent();
-		}
+		List<CommentRespDTO> finds = commentRepository.findByMovieId(comment.getMovieId(), userId, 0).getContent();
 
 		// THEN
 		assertThat(finds.size()).isEqualTo(1);
@@ -159,7 +147,7 @@ public class CommentRepositoryTest {
 
 	@Test
 	@DisplayName("특정 영화의 한줄평을 시간순으로 조회한다.")
-	public void findByMovieIdOnDateDescend() {
+	public void findByMovieIdOnDateDescend() throws InterruptedException {
 		// GIVEN
 		CommentEntity comment2 = CommentEntity.builder()
 			.content("내용2")
@@ -170,22 +158,17 @@ public class CommentRepositoryTest {
 			.userId(userRepository.findByUserEmail("testEmail").get().getUserId())
 			.build();
 		commentRepository.saveNewComment(comment.getMovieId(), comment.getUserId(), comment);
+		Thread.sleep(1000);
 		commentRepository.saveNewComment(comment2.getMovieId(), comment2.getUserId(), comment2);
 
 		// WHEN
-		List<CommentRespDTO> finds;
-		if (commentRepository instanceof MybatisCommentRepository) {
-			finds = commentRepository.findByMovieIdOnDateDescend(comment.getMovieId(), userId, 0);
-		} else {
-			finds = commentRepository.findByMovieIdOrderBy(comment.getMovieId(), userId, PageRequest.of(0, 10, Sort.by(
-					Direction.DESC, "createdAt")))
-				.getContent();
-		}
+		List<CommentRespDTO> finds = commentRepository.findByMovieIdOnDateDescend(comment.getMovieId(), userId, 0)
+			.getContent();
 
 		// THEN
 		Instant later = finds.get(0).getCreatedAt();
 		for (CommentRespDTO find : finds) {
-			assertThat(later).isBeforeOrEqualTo(find.getCreatedAt());
+			assertThat(later).isAfterOrEqualTo(find.getCreatedAt());
 			later = find.getCreatedAt();
 		}
 	}
@@ -206,14 +189,7 @@ public class CommentRepositoryTest {
 		commentRepository.saveNewComment(comment2.getMovieId(), comment2.getUserId(), comment2);
 
 		// WHEN
-		List<CommentRespDTO> finds;
-		if (commentRepository instanceof MybatisCommentRepository) {
-			finds = commentRepository.findByMovieIdOnLikeDescend(comment.getMovieId(), userId, 0);
-		} else {
-			finds = commentRepository.findByMovieIdOrderBy(comment.getMovieId(), userId, PageRequest.of(0, 10, Sort.by(
-					Direction.DESC, "like")))
-				.getContent();
-		}
+		List<CommentRespDTO> finds = commentRepository.findByMovieIdOnLikeDescend(comment.getMovieId(), userId, 0).getContent();
 
 		// THEN
 		int more = finds.get(0).getLike();
@@ -239,14 +215,7 @@ public class CommentRepositoryTest {
 		commentRepository.saveNewComment(comment2.getMovieId(), comment2.getUserId(), comment2);
 
 		// WHEN
-		List<CommentRespDTO> finds;
-		if (commentRepository instanceof MybatisCommentRepository) {
-			finds = commentRepository.findByMovieIdOnDislikeDescend(comment.getMovieId(), userId, 0);
-		} else {
-			finds = commentRepository.findByMovieIdOrderBy(comment.getMovieId(), userId, PageRequest.of(0, 10, Sort.by(
-					Direction.DESC, "dislike")))
-				.getContent();
-		}
+		List<CommentRespDTO> finds = commentRepository.findByMovieIdOnDislikeDescend(comment.getMovieId(), userId, 0).getContent();
 
 		// THEN
 		int more = finds.get(0).getDislike();

--- a/application/src/test/java/core/application/movies/repository/CommentRepositoryTest.java
+++ b/application/src/test/java/core/application/movies/repository/CommentRepositoryTest.java
@@ -12,14 +12,18 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
 import org.springframework.transaction.annotation.Transactional;
 
 import core.application.movies.models.dto.response.CommentRespDTO;
 import core.application.movies.models.entities.CachedMovieEntity;
 import core.application.movies.models.entities.CommentEntity;
-import core.application.movies.repositories.movie.CachedMovieRepository;
 import core.application.movies.repositories.comment.CommentLikeRepository;
 import core.application.movies.repositories.comment.CommentRepository;
+import core.application.movies.repositories.comment.mybatis.MybatisCommentRepository;
+import core.application.movies.repositories.movie.CachedMovieRepository;
 import core.application.users.models.entities.UserEntity;
 import core.application.users.models.entities.UserRole;
 import core.application.users.repositories.UserRepository;
@@ -114,7 +118,13 @@ public class CommentRepositoryTest {
 			comment2);
 
 		// WHEN
-		List<CommentRespDTO> finds = commentRepository.findByMovieId(comment.getMovieId(), null, 0);
+		List<CommentRespDTO> finds;
+		if (commentRepository instanceof MybatisCommentRepository) {
+			finds = commentRepository.findByMovieId(comment.getMovieId(), null, 0);
+		} else {
+			finds = commentRepository.findByMovieIdOrderBy(comment.getMovieId(), null, PageRequest.of(0, 10))
+				.getContent();
+		}
 
 		// THEN
 		assertThat(finds.size()).isEqualTo(2);
@@ -133,7 +143,13 @@ public class CommentRepositoryTest {
 		commentLikeRepository.saveCommentLike(comment.getCommentId(), userId);
 
 		// WHEN
-		List<CommentRespDTO> finds = commentRepository.findByMovieId(comment.getMovieId(), userId, 0);
+		List<CommentRespDTO> finds;
+		if (commentRepository instanceof MybatisCommentRepository) {
+			finds = commentRepository.findByMovieId(comment.getMovieId(), userId, 0);
+		} else {
+			finds = commentRepository.findByMovieIdOrderBy(comment.getMovieId(), userId, PageRequest.of(0, 10))
+				.getContent();
+		}
 
 		// THEN
 		assertThat(finds.size()).isEqualTo(1);
@@ -157,7 +173,14 @@ public class CommentRepositoryTest {
 		commentRepository.saveNewComment(comment2.getMovieId(), comment2.getUserId(), comment2);
 
 		// WHEN
-		List<CommentRespDTO> finds = commentRepository.findByMovieIdOnDateDescend("test", userId, 0);
+		List<CommentRespDTO> finds;
+		if (commentRepository instanceof MybatisCommentRepository) {
+			finds = commentRepository.findByMovieIdOnDateDescend(comment.getMovieId(), userId, 0);
+		} else {
+			finds = commentRepository.findByMovieIdOrderBy(comment.getMovieId(), userId, PageRequest.of(0, 10, Sort.by(
+					Direction.DESC, "createdAt")))
+				.getContent();
+		}
 
 		// THEN
 		Instant later = finds.get(0).getCreatedAt();
@@ -183,7 +206,14 @@ public class CommentRepositoryTest {
 		commentRepository.saveNewComment(comment2.getMovieId(), comment2.getUserId(), comment2);
 
 		// WHEN
-		List<CommentRespDTO> finds = commentRepository.findByMovieIdOnLikeDescend("test", userId, 0);
+		List<CommentRespDTO> finds;
+		if (commentRepository instanceof MybatisCommentRepository) {
+			finds = commentRepository.findByMovieIdOnLikeDescend(comment.getMovieId(), userId, 0);
+		} else {
+			finds = commentRepository.findByMovieIdOrderBy(comment.getMovieId(), userId, PageRequest.of(0, 10, Sort.by(
+					Direction.DESC, "like")))
+				.getContent();
+		}
 
 		// THEN
 		int more = finds.get(0).getLike();
@@ -209,7 +239,14 @@ public class CommentRepositoryTest {
 		commentRepository.saveNewComment(comment2.getMovieId(), comment2.getUserId(), comment2);
 
 		// WHEN
-		List<CommentRespDTO> finds = commentRepository.findByMovieIdOnDislikeDescend("test", userId, 0);
+		List<CommentRespDTO> finds;
+		if (commentRepository instanceof MybatisCommentRepository) {
+			finds = commentRepository.findByMovieIdOnDislikeDescend(comment.getMovieId(), userId, 0);
+		} else {
+			finds = commentRepository.findByMovieIdOrderBy(comment.getMovieId(), userId, PageRequest.of(0, 10, Sort.by(
+					Direction.DESC, "dislike")))
+				.getContent();
+		}
 
 		// THEN
 		int more = finds.get(0).getDislike();

--- a/application/src/test/java/core/application/movies/repository/MovieRepositoryTest.java
+++ b/application/src/test/java/core/application/movies/repository/MovieRepositoryTest.java
@@ -97,10 +97,13 @@ public class MovieRepositoryTest {
 		// WHEN
 		List<CachedMovieEntity> rating = repository.selectOnAVGRatingDescend(5);
 		List<CachedMovieEntity> dib = repository.selectOnDibOrderDescend(5);
-		List<CachedMovieEntity> review = repository.selectOnDibOrderDescend(5);
+		List<CachedMovieEntity> review = repository.selectOnReviewCountDescend(5);
 
 		// THEN
 		assertThat(rating).hasSize(5);
+		for (CachedMovieEntity movie : rating) {
+			System.out.println(movie.getSumOfRating());
+		}
 		assertThat(rating.get(0).getSumOfRating()).isEqualTo(100);
 		assertThat(rating.get(1).getSumOfRating()).isEqualTo(90);
 		assertThat(rating.get(2).getSumOfRating()).isEqualTo(80);
@@ -139,5 +142,55 @@ public class MovieRepositoryTest {
 			assertThat(find.getCommentCount()).isEqualTo(movie.getCommentCount());
 			assertThat(find.getSumOfRating()).isEqualTo(movie.getSumOfRating());
 		});
+	}
+
+	@Test
+	@DisplayName("commentCount가 0인 영화는 평균 평점 정렬 시 최하위에 정렬된다.")
+	public void commentCountTest() {
+		System.out.println(repository.getClass());
+		// GIVEN
+		for (int i = 0; i < 8; i++) {
+			CachedMovieEntity movieEntity = new CachedMovieEntity(
+				"test" + i,
+				"testTitle",
+				"posterUrl",
+				"액션",
+				"2024-09-30",
+				"줄거리",
+				"122",
+				"마동석, 김무열",
+				"봉준호",
+				(long)i, (long)(i), 10L, (long)(1000 - 10 * i)
+			);
+			repository.saveNewMovie(movieEntity);
+		}
+		for (int i = 8; i < 10; i++) {
+			CachedMovieEntity movieEntity = new CachedMovieEntity(
+				"test" + i,
+				"testTitle",
+				"posterUrl",
+				"액션",
+				"2024-09-30",
+				"줄거리",
+				"122",
+				"마동석, 김무열",
+				"봉준호",
+				(long)i, (long)(i), 0L, (long)(1000 - 10 * i)
+			);
+			repository.saveNewMovie(movieEntity);
+		}
+
+		// WHEN
+		List<CachedMovieEntity> movies = repository.selectOnAVGRatingDescend();
+
+		// THEN
+		for (int i = 0; i < 8; i++) {
+			System.out.println(i + " : " + movies.get(i).getMovieId());
+			assertThat(movies.get(i).getSumOfRating()).isEqualTo(1000 - (10 * i));
+			assertThat(movies.get(i).getCommentCount()).isNotEqualTo(0);
+		}
+		for (int i = 8; i < 10; i++) {
+			assertThat(movies.get(i).getCommentCount()).isEqualTo(0);
+		}
 	}
 }

--- a/application/src/test/java/core/application/movies/service/CommentServiceTest.java
+++ b/application/src/test/java/core/application/movies/service/CommentServiceTest.java
@@ -17,12 +17,12 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
 import core.application.movies.constant.CommentSort;
-import core.application.movies.models.dto.response.CommentRespDTO;
 import core.application.movies.models.dto.request.CommentWriteReqDTO;
+import core.application.movies.models.dto.response.CommentRespDTO;
 import core.application.movies.models.entities.CachedMovieEntity;
 import core.application.movies.models.entities.CommentEntity;
-import core.application.movies.repositories.movie.CachedMovieRepository;
 import core.application.movies.repositories.comment.CommentRepository;
+import core.application.movies.repositories.movie.CachedMovieRepository;
 import core.application.users.models.entities.UserEntity;
 import core.application.users.models.entities.UserRole;
 import core.application.users.repositories.UserRepository;
@@ -101,7 +101,7 @@ public class CommentServiceTest {
 		}
 
 		// WHEN
-		List<CommentRespDTO> comments = commentService.getComments(movieId, 0, CommentSort.LATEST, null);
+		List<CommentRespDTO> comments = commentService.getComments(movieId, 0, CommentSort.LATEST, null).getContent();
 
 		// THEN
 		assertThat(comments.size()).isEqualTo(10);
@@ -127,7 +127,7 @@ public class CommentServiceTest {
 		}
 
 		// WHEN
-		List<CommentRespDTO> comments = commentService.getComments(movieId, 0, CommentSort.LIKE, null);
+		List<CommentRespDTO> comments = commentService.getComments(movieId, 0, CommentSort.LIKE, null).getContent();
 
 		// THEN
 		int like = comments.get(0).getLike();
@@ -152,7 +152,7 @@ public class CommentServiceTest {
 		}
 
 		// WHEN
-		List<CommentRespDTO> comments = commentService.getComments(movieId, 0, CommentSort.DISLIKE, null);
+		List<CommentRespDTO> comments = commentService.getComments(movieId, 0, CommentSort.DISLIKE, null).getContent();
 
 		// THEN
 		int dislike = comments.get(0).getDislike();
@@ -250,7 +250,8 @@ public class CommentServiceTest {
 		}
 
 		// WHEN
-		List<CommentRespDTO> comments = commentService.getComments(movieId, 0, CommentSort.LIKE, user.getUserId());
+		List<CommentRespDTO> comments = commentService.getComments(movieId, 0, CommentSort.LIKE, user.getUserId())
+			.getContent();
 
 		// THEN
 		for (CommentRespDTO comment : comments) {


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
#142 PR에서 수정할 부분 수정 후, `movies` 도메인 전체에 대해 올린 PR을 한줄평과 영화로 나누어 올릴 계획입니다.
이번 PR은 한줄평 기능 JPA 마이그레이션 PR입니다.

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->

- 한줄평 관련 Entity에 JPA 어노테이션 추가 909233d463042926e48212fc828ba4aebed6af54
  - 한줄평 좋아요/싫어요의 경우, 기존에 Entity가 따로 존재하지 않아 추가 생성
- 기존 한줄평 관련 마이바티스 구현체 클래스명 및 패키지 위치 변경 0ff98c81916c485d3ca073a2639edc2c6565c7b4
- 한줄평 좋아요/싫어요 Repository 인터페이스 추가 af495901229dc75180d965478575b6f7ffa10b0c
- JPA 구현체 추가에 따른 기존 한줄평 Repository 인터페이스 수정 e04bf58d224bfedbe272ab44a0d97b80f82ce4cf
- JPA Repository 인터페이스 추가 5863a9e06fa29940b0c7e420c1efbc57a066d5ed
- JPA Repository 인터페이스를 이용한 구현체 작성 e654ab2c7c64f2bdaffc0cec968689371ab3f47d
- Repository 인터페이스 수정에 따른 `CommentService` 로직 수정 b79ba9e5353a364f7f9c79b0e7f6b4e41b71c328
- 페이징 처리에 따른 응답값 수정 및 `@PathVariable`, `@Requestparam` 매핑 값 지정
  - 9c6e2c22aa5013db942359f9c6235865fc9754c6
  - f05a5a206ad5bb65889fff6469ac1a9f32142b9f

Mybatis의 경우, Repository에서 `Page<>` 결과값을 받을 수 없습니다. 그래서 `Service`에서 `PageImpl`을 통해 직접 생성하여 반환하였습니다.
그래서 API 응답값 자체가 변경되었습니다. 프론트에서 전체 개수를 알아야 몇 페이지까지 나타낼지 알 수 있을 것이라 생각하기도 하고, 단순히 `List `내에 값을 넣어주는 것으로 페이징에 대한 정보를 제공하기에 부족하다고 생각했습니다. `Page<>`를 사용할 경우 반환값은 다음과 같습니다.
```
"result": {
        "content": [
            {
                "commentId": 898,
                "content": "좋은 영화이군요.",
                "like": 1,
                "dislike": 1,
                "rating": 4,
                "movieId": "K-15376",
                "userId": "e92e197d-8e18-11ef-af7c-d88083a74022",
                "createdAt": "2024-10-20T20:23:31Z",
                "isLiked": false,
                "isDisliked": false
            }
        ],
        "pageable": {
            "pageNumber": 0,
            "pageSize": 10,
            "sort": {
                "empty": false,
                "sorted": true,
                "unsorted": false
            },
            "offset": 0,
            "paged": true,
            "unpaged": false
        },
        "last": true,
        "totalElements": 1,
        "totalPages": 1,
        "size": 10,
        "number": 0,
        "sort": {
            "empty": false,
            "sorted": true,
            "unsorted": false
        },
        "first": true,
        "numberOfElements": 1,
        "empty": false
    }
```

## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->

- `Service`에서 구현체에 따른 코드 분리를 `switch`문을 사용하여 가독성을 높였습니다.
- `CommentMapper`에서 count 쿼리에 대한 오류를 수정하였습니다.

