### PR TITLE
fix: `findByReviewIdWithoutContent` 메서드 @Query 수정

### DIFF
--- a/application/src/main/java/core/application/reviews/repositories/jpa/repositories/JpaReviewRepository.java
+++ b/application/src/main/java/core/application/reviews/repositories/jpa/repositories/JpaReviewRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.*;
 public interface JpaReviewRepository extends JpaRepository<ReviewEntity, Long> {
 
     @Query(" SELECT "
-            + " (r.reviewId, r.title, r.userId, r.movieId, r.like, r.createdAt, r.updatedAt) "
+            + " new ReviewEntity(r.reviewId, r.title, null, r.userId, r.movieId, r.like, r.createdAt, r.updatedAt) "
             + " FROM ReviewEntity r WHERE r.reviewId = :id")
     Optional<ReviewEntity> findByReviewIdWithoutContent(Long id);
 


### PR DESCRIPTION
Related to: #166

<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
`JpaReviewRepository`의 리뷰 내용 제외 조회 로직 수정입니다.

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->

```java
    @Query(" SELECT "
            + " r.reviewId, r.title, null, r.userId, r.movieId, r.like, r.createdAt, r.updatedAt "
            + " FROM ReviewEntity r WHERE r.reviewId = :id")
```

```java
    @Query(" SELECT "
            + " new ReviewEntity(r.reviewId, r.title, null, r.userId, r.movieId, r.like, r.createdAt, r.updatedAt) "
            + " FROM ReviewEntity r WHERE r.reviewId = :id")
```
로 수정하였습니다.


